### PR TITLE
Add `sbe_generate()` cmake-function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ include(CTest)
 include(CMakeDependentOption)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+include(FetchContent)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 include(utils)
@@ -36,39 +37,71 @@ option(SBEPP_BUILD_DOCS "Build documentation" OFF)
 add_subdirectory(sbepp)
 
 if(SBEPP_BUILD_SBEPPC)
+    find_package(fmt QUIET)
+    if (NOT fmt_FOUND)
+        FetchContent_Declare(fmt
+          GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+          GIT_TAG 10.1.1
+        )
+        FetchContent_MakeAvailable(fmt)
+    endif ()
+
+    find_package(pugixml QUIET)
+    if (NOT pugixml_FOUND)
+        FetchContent_Declare(
+          pugixml
+          GIT_REPOSITORY https://github.com/zeux/pugixml.git
+          GIT_TAG v1.14
+        )
+        FetchContent_MakeAvailable(pugixml)
+    endif()
+
     add_subdirectory(sbeppc)
 endif()
 
 if(SBEPP_BUILD_BENCHMARK)
+    find_package(benchmark QUIET)
+    if (NOT GTest_FOUND)
+        if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+            cmake_policy(SET CMP0135 NEW)
+        endif()
+
+        FetchContent_Declare(
+          benchmark
+          URL https://github.com/google/benchmark/archive/refs/tags/v1.8.3.tar.gz
+        )
+
+        set(INSTALL_BENCHMARK OFF)
+        set(BENCHMARK_USE_BUNDLED_GTEST OFF)
+        FetchContent_MakeAvailable(benchmark)
+    endif ()
+
     add_subdirectory(benchmark)
 endif()
 
 if(SBEPP_BUILD_TESTS)
+    enable_testing()
+    message(STATUS "Tests are enabled")
+
+    find_package(GTest QUIET)
+    if (NOT GTest_FOUND)
+        if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+            cmake_policy(SET CMP0135 NEW)
+        endif()
+
+        FetchContent_Declare(
+          googletest
+          URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+        )
+
+        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+        set(INSTALL_GTEST OFF)
+        FetchContent_MakeAvailable(googletest)
+    endif ()
+
     add_subdirectory(test)
 endif()
 
 if(SBEPP_BUILD_DOCS)
     add_subdirectory(doc)
 endif()
-
-install(EXPORT sbepp
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sbepp
-    NAMESPACE sbepp::
-)
-
-write_basic_package_version_file(
-    "sbeppConfigVersion.cmake"
-    COMPATIBILITY SameMajorVersion
-)
-
-install(
-    FILES cmake/sbeppConfig.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sbepp
-    COMPONENT sbepp
-)
-
-install(
-    FILES "${PROJECT_BINARY_DIR}/sbeppConfigVersion.cmake"
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sbepp
-    COMPONENT sbepp
-)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,18 +1,14 @@
-find_package(benchmark REQUIRED)
 
 set(schema_name "benchmark_schema")
-set(schema_file "${CMAKE_CURRENT_LIST_DIR}/${schema_name}.xml")
-set(output_file "${CMAKE_CURRENT_BINARY_DIR}/${schema_name}/${schema_name}.hpp")
 
-add_custom_command(
-    OUTPUT ${output_file}
-    COMMAND $<TARGET_FILE:sbepp::sbeppc> "${schema_file}"
-    DEPENDS sbepp::sbeppc "${schema_file}"
+sbepp_generate(
+    SCHEMA_NAME ${schema_name}
+    SCHEMA_FILE ${CMAKE_CURRENT_LIST_DIR}/${schema_name}.xml
+    OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}
+    TARGET_NAME compile_benchmark_schema
 )
 
-add_custom_target(compile_benchmark_schema DEPENDS ${output_file})
-
-set(target "benchmark")
+set(target "sbepp-benchmark")
 set(src_dir "src/sbepp/benchmark")
 
 add_executable(${target})

--- a/cmake/sbepp-generate.cmake
+++ b/cmake/sbepp-generate.cmake
@@ -1,0 +1,111 @@
+# A helper function to integrate sbepp-files generation into cmake-project.
+#
+# sbepp_generate(
+#     # Override schema name (optional).
+#     # Value must be a valid C identiier.
+#     [SCHEMA_NAME <string>]
+#
+#     # XML-file containing sbe-schema definition.
+#     SCHEMA_FILE <path>
+#
+#     # Where the generated file will be created (usually relative to
+#     # PROJECT_BINARY_DIR or to CMAKE_CURRENT_BINARY_DIR).
+#     OUT_DIR <path>
+#
+#     # Target name for custom target that is created to rune generation
+#     # over specified schema definition.
+#     # The value of TARGET_NAME can be the same for multiple calls
+#     # of `sbepp_generate()` function, thus a single target
+#     # can be used to generate sbepp files for multiple schemas.
+#     TARGET_NAME <target-name>
+# )
+function(sbepp_generate)
+  include(CMakeParseArguments)
+
+  set(_singleargs SCHEMA_NAME SCHEMA_FILE OUT_DIR TARGET_NAME)
+
+  cmake_parse_arguments(sbepp_generate "" "${_singleargs}" "" "${ARGN}")
+
+  # Check mandatory agrs:
+  #   * SCHEMA_FILE;
+  #   * OUT_DIR;
+  #   * TARGET_NAME.
+  if ("${sbepp_generate_SCHEMA_FILE}" STREQUAL "")
+    message(FATAL_ERROR "[sbepp_generate] error: missing SCHEMA_FILE parameter")
+  endif ()
+  if ("${sbepp_generate_OUT_DIR}" STREQUAL "")
+    message(FATAL_ERROR "[sbepp_generate] error: missing OUT_DIR parameter")
+  endif ()
+  if ("${sbepp_generate_TARGET_NAME}" STREQUAL "")
+    message(FATAL_ERROR "[sbepp_generate] error: missing TARGET_NAME parameter")
+  endif ()
+
+  # Check that SCHEMA_NAME is valid C identifier.
+  if (NOT "${sbepp_generate_SCHEMA_NAME}" STREQUAL "")
+    string(MAKE_C_IDENTIFIER "${sbepp_generate_SCHEMA_NAME}" _schema_c_identifier)
+
+    if (NOT "${sbepp_generate_SCHEMA_NAME}" STREQUAL "${_schema_c_identifier}")
+      message(FATAL_ERROR "[sbepp_generate] error: SCHEMA_NAME parameter must be valid C identiier")
+    endif ()
+  endif ()
+
+  message(STATUS "[sbepp_generate] parameters:"
+            "\n                    SCHEMA_NAME=${sbepp_generate_SCHEMA_NAME}"
+            "\n                    SCHEMA_FILE=${sbepp_generate_SCHEMA_FILE}"
+            "\n                    OUT_DIR=${sbepp_generate_OUT_DIR}"
+            "\n                    TARGET_NAME=${sbepp_generate_TARGET_NAME}")
+
+  # Create generator anchor file.
+  # This file would be used for a empty file that will
+  # allow to skip generation on every build having no changes
+  # in SCHEMA_FILE or sbeppc.
+  get_filename_component(schema_file_name "${sbepp_generate_SCHEMA_FILE}" NAME)
+  cmake_path(APPEND generator_anchor_file ${sbepp_generate_OUT_DIR} ${schema_file_name}.gen)
+  message(STATUS "[sbepp_generate] generator_anchor_file: ${generator_anchor_file}")
+
+  add_custom_command(
+      VERBATIM
+
+      # Main generate command.
+      COMMAND
+          $<TARGET_FILE:sbepp::sbeppc>
+          $<IF:$<STREQUAL:"${sbepp_generate_SCHEMA_NAME}","">,,--schema-name>
+          "${sbepp_generate_SCHEMA_NAME}"
+          "--output-dir"
+          "${sbepp_generate_OUT_DIR}"
+          "${sbepp_generate_SCHEMA_FILE}"
+
+      # Create a aux file the name of which is fixed.
+      # Because the names of generated files might be defined within XML
+      # we cannot get a reliable names bosed on parameters of this function.
+      # This file would be used as output of this custom command.
+      # It would be used as DEPENDS parameter for custom target.
+      COMMAND
+          ${CMAKE_COMMAND} -E touch ${generator_anchor_file}
+      DEPENDS
+          sbepp::sbeppc
+          "${sbepp_generate_SCHEMA_FILE}"
+
+      OUTPUT ${generator_anchor_file}
+  )
+
+  if (NOT TARGET ${sbepp_generate_TARGET_NAME})
+    message(STATUS "[sbepp_generate] create custom target '${sbepp_generate_TARGET_NAME}'")
+    add_custom_target(
+      ${sbepp_generate_TARGET_NAME}
+      # We don't know all series of generated sbepp-files in advance.
+      # Because if sbepp_generate function as called multiple times
+      # we cannot set DEPENDS parameter using hardcoded list.
+      # So a generator expression is used here to take a final array
+      # from target's SBEPPC_ANCHORS propery.
+      # SBEPPC_ANCHORS is used to accumulate all the generate-command outputs.
+      DEPENDS $<TARGET_PROPERTY:${sbepp_generate_TARGET_NAME},SBEPPC_ANCHORS>)
+  endif ()
+
+  message(STATUS "[sbepp_generate] append SBEPPC_ANCHORS property of '${sbepp_generate_TARGET_NAME}' target: ${generator_anchor_file}")
+  # Add yet another DEPENDS parameter to our custom target that forces
+  # generation commands to run.
+  set_property(TARGET ${sbepp_generate_TARGET_NAME}
+    APPEND PROPERTY SBEPPC_ANCHORS ${generator_anchor_file}
+  )
+endfunction()

--- a/cmake/sbeppConfig.cmake
+++ b/cmake/sbeppConfig.cmake
@@ -1,1 +1,2 @@
 include("${CMAKE_CURRENT_LIST_DIR}/sbepp.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/protobuf-generate.cmake")

--- a/sbepp/CMakeLists.txt
+++ b/sbepp/CMakeLists.txt
@@ -20,3 +20,25 @@ install(
     DIRECTORY src/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
+
+install(EXPORT sbepp
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sbepp
+    NAMESPACE sbepp::
+)
+
+write_basic_package_version_file(
+    "sbeppConfigVersion.cmake"
+    COMPATIBILITY SameMajorVersion
+)
+
+install(
+    FILES ${CMAKE_SOURCE_DIR}/cmake/sbeppConfig.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sbepp
+    COMPONENT sbepp
+)
+
+install(
+    FILES "${PROJECT_BINARY_DIR}/sbepp/sbeppConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sbepp
+    COMPONENT sbepp
+)

--- a/sbeppc/CMakeLists.txt
+++ b/sbeppc/CMakeLists.txt
@@ -1,6 +1,3 @@
-find_package(fmt REQUIRED)
-find_package(pugixml REQUIRED)
-
 set(target "sbepp_sbeppc")
 add_executable(${target})
 add_executable(sbepp::sbeppc ALIAS ${target})
@@ -8,6 +5,8 @@ set_target_properties(${target} PROPERTIES
     OUTPUT_NAME sbeppc
     EXPORT_NAME sbeppc
 )
+
+include(sbepp-generate)
 
 set(src_dir src/sbepp/sbeppc)
 
@@ -34,3 +33,8 @@ install(TARGETS ${target}
     EXPORT sbepp
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+
+install(
+    FILES ${CMAKE_SOURCE_DIR}/cmake/sbepp-generate.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sbepp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(GTest REQUIRED)
-find_package(fmt REQUIRED)
 include(GoogleTest)
 
 function(get_available_cpp_versions result)
@@ -23,21 +21,13 @@ set(test_schemas
 )
 
 foreach(schema IN LISTS test_schemas)
-    # multi-file compilation
-    set(output_file "${CMAKE_CURRENT_BINARY_DIR}/${schema}/${schema}.hpp")
-    list(APPEND schema_output_files ${output_file})
-
-    add_custom_command(
-        OUTPUT ${output_file}
-        # actually, only `traits_test_schema2` needs explicit name
-        COMMAND $<TARGET_FILE:sbepp::sbeppc>
-            "--schema-name" "${schema}"
-            "${CMAKE_CURRENT_LIST_DIR}/schemas/${schema}.xml"
-        DEPENDS sbepp::sbeppc "${CMAKE_CURRENT_LIST_DIR}/schemas/${schema}.xml"
+    sbepp_generate(
+        SCHEMA_NAME ${schema}
+        SCHEMA_FILE ${CMAKE_CURRENT_LIST_DIR}/schemas/${schema}.xml
+        OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}
+        TARGET_NAME compile_test_schemas
     )
 endforeach()
-
-add_custom_target(compile_test_schemas DEPENDS ${schema_output_files})
 
 get_available_cpp_versions(cpp_versions)
 


### PR DESCRIPTION
The change adds `sbe_generate()` function which enables cmake projects to use sbepp-compiler by using a function which accepts `TARGET_NAME` argument. The specified target can be used later by lib/exe cmake-targets in order to run all necessary code generation. This hides all the trickery with custom commands. Similar approach is used in Protobuf library.

Example:
```cmake
sbepp_generate(
    SCHEMA_NAME ${schema_name}
    SCHEMA_FILE ${CMAKE_CURRENT_LIST_DIR}/${schema_name}.xml
    OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}
    TARGET_NAME compile_benchmark_schema
)

# ...

add_executable(${target})
add_dependencies(${target} compile_benchmark_schema)
```