### PR TITLE
remove `!empty()` assertion from `dynamic_array_ref::data()`

### DIFF
--- a/sbepp/src/sbepp/sbepp.hpp
+++ b/sbepp/src/sbepp/sbepp.hpp
@@ -2991,8 +2991,9 @@ public:
 
     //! @brief Access the first element
     //! @pre `!empty()`
-    constexpr reference front() const noexcept
+    SBEPP_CPP14_CONSTEXPR reference front() const noexcept
     {
+        SBEPP_ASSERT(!empty());
         return *data();
     }
 
@@ -3000,14 +3001,19 @@ public:
     //! @pre `!empty()`
     SBEPP_CPP20_CONSTEXPR reference back() const noexcept
     {
+        SBEPP_ASSERT(!empty());
         return *(data() + size() - 1);
     }
 
-    //! @brief Direct access to the underlying array
-    //! @pre `!empty()`
+    /**
+     * @brief Direct access to the underlying array
+     *
+     *  The pointer is such that range `[data(), data() + size())` is always a
+     *  valid range, even if the container is empty (`data()` is not
+     *  dereferenceable in that case).
+     */
     SBEPP_CPP14_CONSTEXPR pointer data() const noexcept
     {
-        SBEPP_ASSERT(!empty());
         return data_checked();
     }
 

--- a/test/src/sbepp/test/dynamic_array_ref.test.cpp
+++ b/test/src/sbepp/test/dynamic_array_ref.test.cpp
@@ -313,11 +313,14 @@ TEST_F(DynamicArrayRefTest, DataReturnsPointerToFirstElement)
     STATIC_ASSERT(noexcept(a.data()));
 }
 
-TEST_F(DynamicArrayRefDeathTest, DataTerminatesIfEmpty)
+TEST_F(DynamicArrayRefTest, DataReturnsPointerAfterLengthIfEmpty)
 {
+    a.clear();
     ASSERT_TRUE(a.empty());
 
-    ASSERT_DEATH({ a.data(); }, ".*");
+    ASSERT_EQ(
+        reinterpret_cast<byte_type*>(a.data()),
+        sbepp::addressof(a) + sizeof(sbe_length_type));
 }
 
 TEST_F(DynamicArrayRefTest, SubscriptReturnsReferenceToElement)


### PR DESCRIPTION
Fixes #21