### PR TITLE
Make more functions C++11 `constexpr`

### DIFF
--- a/sbeppc/src/sbepp/sbeppc/messages_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/messages_compiler.hpp
@@ -460,8 +460,8 @@ public:
     {size_bytes_impl}
 
     template<typename Visitor, typename Cursor>
-    SBEPP_CPP14_CONSTEXPR bool operator()(
-        ::sbepp::detail::visit_tag, Visitor& v, Cursor& c)
+    constexpr bool operator()(
+        ::sbepp::detail::visit_tag, Visitor& v, Cursor& c) const
     {{
         return v.template on_entry(*this, c);
     }}
@@ -626,8 +626,8 @@ public:
     {header_filler}
 
     template<typename Visitor, typename Cursor>
-    SBEPP_CPP14_CONSTEXPR bool operator()(
-        ::sbepp::detail::visit_tag, Visitor& v, Cursor& c)
+    constexpr bool operator()(
+        ::sbepp::detail::visit_tag, Visitor& v, Cursor& c) const
     {{
         return v.template on_group(*this, c, "{public_name}");
     }}
@@ -1755,11 +1755,9 @@ R"(
             // clang-format off
 R"(
     template<typename Visitor, typename Cursor>
-    SBEPP_CPP14_CONSTEXPR bool operator()(
-        ::sbepp::detail::visit_children_tag, Visitor& v, Cursor& c)
+    constexpr bool operator()(
+        ::sbepp::detail::visit_children_tag, Visitor& v, Cursor& c) const
     {{
-        (void)v;
-        (void)c;
         return {member_visitors};
     }}
 )",
@@ -1791,6 +1789,8 @@ R"(
             is_flat_level(m.members), get_last_member(m.members), header.size);
         const auto visit_children_impl = make_visit_children(m.members);
 
+        // it's not possible to make `operator()(visit_tag)` `constexpr` because
+        // C++11 doesn't allow such function to return `void`
         const auto implementation = fmt::format(
             // clang-format off
 R"(

--- a/sbeppc/src/sbepp/sbeppc/types_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/types_compiler.hpp
@@ -631,10 +631,9 @@ public:
             // clang-format off
 R"(
     template<typename Visitor, typename Cursor>
-    SBEPP_CPP14_CONSTEXPR bool operator()(
-        ::sbepp::detail::visit_children_tag, Visitor& v, Cursor&)
+    constexpr bool operator()(
+        ::sbepp::detail::visit_children_tag, Visitor& v, Cursor&) const
     {{
-        (void)v;
         return {children_visitors};
     }}
 )",
@@ -744,8 +743,8 @@ public:
     }}
 
     template<typename Visitor, typename Cursor>
-    SBEPP_CPP14_CONSTEXPR bool operator()(
-        ::sbepp::detail::visit_tag, Visitor& v, Cursor&)
+    constexpr bool operator()(
+        ::sbepp::detail::visit_tag, Visitor& v, Cursor&) const
     {{
         return v.template on_composite(*this, {tag}{{}});
     }}

--- a/sbeppc/src/sbepp/sbeppc/types_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/types_compiler.hpp
@@ -737,7 +737,7 @@ public:
 
 {accessors}
 
-    SBEPP_CPP20_CONSTEXPR std::size_t
+    constexpr std::size_t
         operator()(::sbepp::detail::size_bytes_tag) const noexcept
     {{
         return {size};

--- a/test/src/sbepp/test/composite.test.cpp
+++ b/test/src/sbepp/test/composite.test.cpp
@@ -354,13 +354,15 @@ TYPED_TEST(
 
 TEST(SizeBytesTest, SizeBytesReturnsSizeOfAllFields)
 {
-    // use composite_11 to test with custom offsets?
     std::array<char, 256> buf{};
-    test_schema::types::composite_a<char> c{buf.data(), buf.size()};
+    composite_t c{buf.data(), buf.size()};
     const auto total_fields_size = sizeof(c.x()) + sizeof(c.y());
 
     ASSERT_EQ(sbepp::size_bytes(c), total_fields_size);
     STATIC_ASSERT(noexcept(sbepp::size_bytes(c)));
+
+    // constexpr test
+    STATIC_ASSERT(sbepp::size_bytes(composite_t{}) == total_fields_size);
 }
 
 TEST(SizeBytesTest, SizeBytesTakesCustomOffsetsIntoAccount)


### PR DESCRIPTION
Use plain `constexpr` keyword in more places. Probably the only noticeable effect of this change is that `size_bytes(composite_type{})` is now fully `constexpr` even in C++11.