### PR TITLE
Add `size_bytes()` for message/group/data traits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(sbepp
-    VERSION 1.2.0
+    VERSION 1.3.0
     LANGUAGES CXX
 )
 

--- a/sbepp/src/sbepp/sbepp.hpp
+++ b/sbepp/src/sbepp/sbepp.hpp
@@ -4054,6 +4054,8 @@ public:
      * </sbe:message>
      * ```
      *
+     * For usage example, see @ref example-size-bytes.
+     *
      * @warning This function provides correct results only for the current
      *  schema version.
      */

--- a/sbeppc/src/sbepp/sbeppc/messages_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/messages_compiler.hpp
@@ -348,29 +348,10 @@ R"(
         return {};
     }
 
-    static const sbe::composite_element* find_composite_element(
-        const sbe::composite& c, const std::string_view name)
-    {
-        const auto search = std::find_if(
-            std::begin(c.elements),
-            std::end(c.elements),
-            [name](const auto& element)
-            {
-                return utils::get_encoding_name(element) == name;
-            });
-
-        if(search != std::end(c.elements))
-        {
-            return &*search;
-        }
-
-        return {};
-    }
-
     static std::string_view get_block_length_type(const sbe::composite& c)
     {
-        const auto t =
-            std::get_if<sbe::type>(find_composite_element(c, "blockLength"));
+        const auto t = std::get_if<sbe::type>(
+            utils::find_composite_element(c, "blockLength"));
         if(t)
         {
             return t->underlying_type;
@@ -504,8 +485,8 @@ public:
 
     static std::string_view get_num_in_group_type(const sbe::composite& c)
     {
-        const auto t =
-            std::get_if<sbe::type>(find_composite_element(c, "numInGroup"));
+        const auto t = std::get_if<sbe::type>(
+            utils::find_composite_element(c, "numInGroup"));
         if(t)
         {
             return t->impl_type;
@@ -699,7 +680,7 @@ R"(
         dependencies.emplace(c.name);
 
         const auto t =
-            std::get_if<sbe::type>(find_composite_element(c, "length"));
+            std::get_if<sbe::type>(utils::find_composite_element(c, "length"));
         if(t)
         {
             return *t;
@@ -717,7 +698,7 @@ R"(
             d.type);
 
         const auto t =
-            std::get_if<sbe::type>(find_composite_element(c, "varData"));
+            std::get_if<sbe::type>(utils::find_composite_element(c, "varData"));
         if(t)
         {
             return t->underlying_type;
@@ -1588,12 +1569,12 @@ R"(
 
     static bool has_num_groups(const sbe::composite& c)
     {
-        return find_composite_element(c, "numGroups");
+        return utils::find_composite_element(c, "numGroups");
     }
 
     static bool has_num_var_data_fields(const sbe::composite& c)
     {
-        return find_composite_element(c, "numVarDataFields");
+        return utils::find_composite_element(c, "numVarDataFields");
     }
 
     static std::string make_num_groups_setter(

--- a/sbeppc/src/sbepp/sbeppc/traits_generator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/traits_generator.hpp
@@ -749,8 +749,8 @@ public:
             {
                 params += ", ";
             }
-            params +=
-                fmt::format("const {} {}", param_types[i], param_names[i]);
+            params += fmt::format(
+                "\n        const {} {}", param_types[i], param_names[i]);
         }
 
         return params;

--- a/sbeppc/src/sbepp/sbeppc/traits_generator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/traits_generator.hpp
@@ -13,6 +13,8 @@
 #include <fmt/core.h>
 
 #include <string>
+#include <iterator>
+#include <vector>
 
 namespace sbepp::sbeppc
 {
@@ -93,7 +95,7 @@ public:
 
     std::string make_message_traits(const sbe::message& m) const
     {
-        return make_message_root_traits(m) + make_level_traits(m.members);
+        return make_level_traits(m.members) + make_message_root_traits(m);
     }
 
     std::string make_type_traits(const sbe::encoding& enc) const
@@ -107,6 +109,22 @@ public:
     }
 
 private:
+    struct group_size_bytes_info
+    {
+        std::vector<std::string> param_names;
+        std::vector<std::string> param_types;
+        bool has_data_members;
+    };
+
+    struct level_size_bytes_info
+    {
+        std::vector<std::string> param_names;
+        std::vector<std::string> param_types;
+        // does not include trailing `total_data_size` term
+        std::vector<std::string> sum_terms;
+        bool has_data_members;
+    };
+
     const sbe::message_schema* schema;
     const type_manager* types;
 
@@ -617,7 +635,254 @@ public:
             fmt::arg("deprecated_impl", make_deprecated(r.deprecated_since)));
     }
 
-    static std::string make_message_root_traits(const sbe::message& m)
+    std::string get_num_in_group_underlying_type(const sbe::group& g) const
+    {
+        const auto& header = types->get_as_or_throw<sbe::composite>(
+            g.dimension_type,
+            "{}: encoding `{}` doesn't exist or it's not a composite");
+
+        const auto t = std::get_if<sbe::type>(
+            utils::find_composite_element(header, "numInGroup"));
+        if(t)
+        {
+            return t->underlying_type;
+        }
+
+        throw_error(
+            "{}: `numInGroup` is not found or it's not a type",
+            header.location);
+    }
+
+    static bool
+        vector_contains(const std::vector<std::string>& v, const std::string& s)
+    {
+        return (std::find(std::begin(v), std::end(v), s) != std::end(v));
+    }
+
+    static std::string make_unique_param_name(
+        std::string desired_name,
+        const std::vector<std::string>& existing_names1,
+        const std::vector<std::string>& existing_names2,
+        const std::size_t level_depth)
+    {
+        // names on the same level are always unique but it's not guaranteed for
+        // names from different levels (which are concatenated to create group
+        // size parameter name). By adding `_<depth>` suffix we ensure that
+        // there will be no two identical parameter names because each level has
+        // unique suffix which is used only in case of conflicts.
+        if(vector_contains(existing_names1, desired_name)
+           || vector_contains(existing_names2, desired_name))
+        {
+            return fmt::format("{}_{}", desired_name, level_depth);
+        }
+
+        return desired_name;
+    }
+
+    void get_group_size_bytes_info_impl(
+        const sbe::group& g,
+        const std::vector<std::string>& existing_names,
+        std::vector<std::string>& path,
+        group_size_bytes_info& info) const
+    {
+        path.push_back(g.name);
+
+        info.param_names.push_back(make_unique_param_name(
+            fmt::format("{}_num_in_group", fmt::join(path, "_")),
+            existing_names,
+            info.param_names,
+            path.size() - 1));
+        info.param_types.push_back(get_num_in_group_underlying_type(g));
+
+        for(const auto& nested_group : g.members.groups)
+        {
+            get_group_size_bytes_info_impl(
+                nested_group, existing_names, path, info);
+        }
+
+        info.has_data_members |= !g.members.data.empty();
+        path.pop_back();
+    }
+
+    group_size_bytes_info get_group_size_bytes_info(
+        const sbe::group& g,
+        const std::vector<std::string>& existing_names,
+        std::vector<std::string>& path) const
+    {
+        group_size_bytes_info info{};
+        get_group_size_bytes_info_impl(g, existing_names, path, info);
+
+        return info;
+    }
+
+    static std::string
+        make_group_size_bytes_args(const group_size_bytes_info& info)
+    {
+        auto args = fmt::format("{}", fmt::join(info.param_names, ", "));
+        if(info.has_data_members)
+        {
+            if(args.empty())
+            {
+                args = "0";
+            }
+            else
+            {
+                args += ", 0";
+            }
+        }
+
+        return args;
+    }
+
+    static void append_vector(
+        std::vector<std::string>& to, std::vector<std::string> from)
+    {
+        to.insert(
+            std::end(to),
+            std::make_move_iterator(std::begin(from)),
+            std::make_move_iterator(std::end(from)));
+    }
+
+    level_size_bytes_info
+        get_level_size_bytes_info(const sbe::level_members& members) const
+    {
+        level_size_bytes_info info{};
+        std::vector<std::string> path;
+
+        for(const auto& g : members.groups)
+        {
+            auto group_info =
+                get_group_size_bytes_info(g, info.param_names, path);
+
+            info.has_data_members |= group_info.has_data_members;
+
+            info.sum_terms.push_back(fmt::format(
+                "::sbepp::group_traits<{tag}>::size_bytes({args})",
+                fmt::arg("tag", g.tag),
+                fmt::arg("args", make_group_size_bytes_args(group_info))));
+            append_vector(info.param_names, std::move(group_info.param_names));
+            append_vector(info.param_types, std::move(group_info.param_types));
+        }
+
+        for(const auto& d : members.data)
+        {
+            info.has_data_members = true;
+            info.sum_terms.push_back(
+                fmt::format("::sbepp::data_traits<{}>::size_bytes(0)", d.tag));
+        }
+
+        return info;
+    }
+
+    static std::string make_size_bytes_params(const level_size_bytes_info& info)
+    {
+        std::string params;
+        bool is_first_param{true};
+
+        for(std::size_t i = 0; i != info.param_types.size(); i++)
+        {
+            if(is_first_param)
+            {
+                is_first_param = false;
+            }
+            else
+            {
+                params += ", ";
+            }
+
+            params += fmt::format(
+                "const {} {}", info.param_types[i], info.param_names[i]);
+        }
+
+        if(info.has_data_members)
+        {
+            if(!is_first_param)
+            {
+                params += ", ";
+            }
+            params += "const ::std::size_t total_data_size";
+        }
+
+        return params;
+    }
+
+    std::string make_group_size_bytes_params(
+        const sbe::group& g, const level_size_bytes_info& info) const
+    {
+        auto params = fmt::format(
+            "const {} num_in_group", get_num_in_group_underlying_type(g));
+        const auto optional_params = make_size_bytes_params(info);
+
+        if(!optional_params.empty())
+        {
+            params += ", ";
+            params += optional_params;
+        }
+
+        return params;
+    }
+
+    std::string make_group_size_bytes(const sbe::group& g) const
+    {
+        auto info = get_level_size_bytes_info(g.members);
+
+        if(!info.sum_terms.empty())
+        {
+            // adding empty string just to have `+` prefix when it's joined
+            info.sum_terms.emplace(std::begin(info.sum_terms), "");
+        }
+
+        auto body_size = fmt::format(
+            "num_in_group * (block_length() {})",
+            fmt::join(info.sum_terms, "\n+ "));
+
+        if(info.has_data_members)
+        {
+            body_size += "\n+ total_data_size";
+        }
+
+        return fmt::format(
+            // clang-format off
+R"(static constexpr ::std::size_t size_bytes({params}) noexcept
+    {{
+        return ::sbepp::composite_traits<dimension_type_tag>::size_bytes()
+            + {body_size};
+    }}
+)",
+            // clang-format on
+            fmt::arg("params", make_group_size_bytes_params(g, info)),
+            fmt::arg("body_size", body_size));
+    }
+
+    std::string make_message_size_bytes(const sbe::message& m) const
+    {
+        auto info = get_level_size_bytes_info(m.members);
+        if(info.has_data_members)
+        {
+            info.sum_terms.emplace_back("total_data_size");
+        }
+
+        if(!info.sum_terms.empty())
+        {
+            // adding empty string just to have `+` prefix when it's joined
+            info.sum_terms.emplace(std::begin(info.sum_terms), "");
+        }
+
+        return fmt::format(
+            // clang-format off
+R"(static constexpr ::std::size_t size_bytes({params}) noexcept
+    {{
+        return ::sbepp::composite_traits<
+            ::sbepp::schema_traits<schema_tag>::header_type_tag>::size_bytes()
+        + block_length() {sum_terms};
+    }}
+)",
+            // clang-format on
+            fmt::arg("params", make_size_bytes_params(info)),
+            fmt::arg("sum_terms", fmt::join(info.sum_terms, "\n+ ")));
+    }
+
+    std::string make_message_root_traits(const sbe::message& m) const
     {
         return fmt::format(
             // clang-format off
@@ -658,6 +923,8 @@ public:
 
     {deprecated_impl}
     {value_type}
+    {schema_tag}
+    {size_bytes_impl}
 }};
 )",
             // clang-format on
@@ -671,7 +938,11 @@ public:
             fmt::arg(
                 "value_type",
                 utils::make_alias_template("value_type", m.public_type)),
-            fmt::arg("deprecated_impl", make_deprecated(m.deprecated_since)));
+            fmt::arg("deprecated_impl", make_deprecated(m.deprecated_since)),
+            fmt::arg("size_bytes_impl", make_message_size_bytes(m)),
+            fmt::arg(
+                "schema_tag",
+                utils::make_type_alias("schema_tag", schema->tag)));
     }
 
     static std::string make_field_value_type(const sbe::field& f)
@@ -771,6 +1042,8 @@ public:
         return fmt::format(
             // clang-format off
 R"(
+{level_traits}
+
 template<>
 class group_traits<{tag}>
 {{
@@ -810,9 +1083,8 @@ public:
     {dimension_type}
     {dimension_type_tag}
     {entry_type}
+    {size_bytes_impl}
 }};
-
-{level_traits}
 )",
             // clang-format on
             fmt::arg("tag", g.tag),
@@ -837,7 +1109,8 @@ public:
                 "entry_type",
                 utils::make_alias_template("entry_type", g.entry_impl_type)),
             fmt::arg("level_traits", make_level_traits(g.members)),
-            fmt::arg("deprecated_impl", make_deprecated(g.deprecated_since)));
+            fmt::arg("deprecated_impl", make_deprecated(g.deprecated_since)),
+            fmt::arg("size_bytes_impl", make_group_size_bytes(g)));
     }
 
     static std::string make_traits(const sbe::data& d)
@@ -875,6 +1148,12 @@ public:
 
     {length_type}
     {length_type_tag}
+
+    static constexpr ::std::size_t size_bytes(
+        const length_type::value_type size) noexcept
+    {{
+        return sizeof(size) + size;
+    }}
 }};
 )",
             // clang-format on

--- a/sbeppc/src/sbepp/sbeppc/utils.hpp
+++ b/sbeppc/src/sbepp/sbeppc/utils.hpp
@@ -523,4 +523,23 @@ inline std::optional<std::string> numeric_literal_to_value(
 
     return utils::to_integer_literal(*value, location);
 }
+
+inline const sbe::composite_element*
+    find_composite_element(const sbe::composite& c, const std::string_view name)
+{
+    const auto search = std::find_if(
+        std::begin(c.elements),
+        std::end(c.elements),
+        [name](const auto& element)
+        {
+            return utils::get_encoding_name(element) == name;
+        });
+
+    if(search != std::end(c.elements))
+    {
+        return &*search;
+    }
+
+    return {};
+}
 } // namespace sbepp::sbeppc::utils

--- a/test/schemas/traits_test_schema.xml
+++ b/test/schemas/traits_test_schema.xml
@@ -150,4 +150,106 @@
             <field name="field_3" id="3" type="uint32"/>
         </group>
     </sbe:message>
+
+    <!-- size_bytes tests -->
+    <sbe:message name="msg_7" id="7">
+    </sbe:message>
+
+    <sbe:message name="msg_8" id="8">
+        <field name="field" id="1" type="uint32"/>
+    </sbe:message>
+
+    <sbe:message name="msg_9" id="9">
+        <data name="data_1" id="1" type="varDataEncoding"/>
+        <data name="data_2" id="2" type="varDataEncoding"/>
+    </sbe:message>
+
+    <sbe:message name="msg_10" id="10">
+        <field name="field" id="1" type="uint32"/>
+
+        <group name="group_1" id="2">
+            <field name="field" id="3" type="uint32"/>
+        </group>
+        <group name="group_2" id="4"/>
+    </sbe:message>
+
+    <sbe:message name="msg_11" id="11">
+        <field name="field" id="1" type="uint32"/>
+
+        <group name="group" id="2">
+            <field name="field" id="3" type="uint32"/>
+        </group>
+
+        <data name="data" id="4" type="varDataEncoding"/>
+    </sbe:message>
+
+    <sbe:message name="msg_12" id="12">
+        <field name="field" id="1" type="uint32"/>
+
+        <group name="group_1" id="2">
+            <field name="field" id="3" type="uint32"/>
+        </group>
+        <group name="group_2" id="4">
+            <field name="field" id="5" type="uint32"/>
+        </group>
+    </sbe:message>
+
+    <sbe:message name="msg_13" id="13">
+        <field name="field" id="1" type="uint32"/>
+
+        <group name="group_1" id="2">
+            <field name="field" id="3" type="uint32"/>
+
+            <group name="group_2" id="4">
+                <field name="field" id="5" type="uint32"/>
+            </group>
+        </group>
+    </sbe:message>
+
+    <sbe:message name="msg_14" id="14">
+        <field name="field" id="1" type="uint32"/>
+
+        <group name="group_1" id="2">
+            <field name="field" id="3" type="uint32"/>
+
+            <group name="group_2" id="4">
+                <field name="field" id="5" type="uint32"/>
+                <data name="data" id="6" type="varDataEncoding"/>
+            </group>
+        </group>
+    </sbe:message>
+
+    <sbe:message name="msg_15" id="15">
+        <field name="field" id="1" type="uint32"/>
+
+        <group name="group_1" id="2">
+            <field name="field" id="3" type="uint32"/>
+
+            <group name="group_2" id="4">
+                <field name="field" id="5" type="uint32"/>
+                <data name="data" id="6" type="varDataEncoding"/>
+            </group>
+
+            <data name="data" id="7" type="varDataEncoding"/>
+        </group>
+
+        <data name="data" id="7" type="varDataEncoding"/>
+    </sbe:message>
+
+    <sbe:message name="msg_16" id="16">
+        <group name="group_1" id="2">
+            <group name="group_2" id="4"/>
+        </group>
+
+        <group name="group_1_group_2" id="2"/>
+
+        <group name="group_3" id="2">
+            <group name="group_1_group_2" id="2"/>
+
+            <group name="group_1" id="2">
+                <group name="group_2" id="4"/>
+                <data name="data" id="7" type="varDataEncoding"/>
+            </group>
+        </group>
+    </sbe:message>
 </sbe:messageSchema>

--- a/test/src/sbepp/test/built_in_types.test.cpp
+++ b/test/src/sbepp/test/built_in_types.test.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2023, Oleksandr Koval
+
 #include <sbepp/sbepp.hpp>
 
 #include <gtest/gtest.h>

--- a/test/src/sbepp/test/traits.test.cpp
+++ b/test/src/sbepp/test/traits.test.cpp
@@ -35,6 +35,16 @@
 #    include <traits_test_schema/messages/msg_4.hpp>
 #    include <traits_test_schema/messages/msg_5.hpp>
 #    include <traits_test_schema/messages/msg_6.hpp>
+#    include <traits_test_schema/messages/msg_7.hpp>
+#    include <traits_test_schema/messages/msg_8.hpp>
+#    include <traits_test_schema/messages/msg_9.hpp>
+#    include <traits_test_schema/messages/msg_10.hpp>
+#    include <traits_test_schema/messages/msg_11.hpp>
+#    include <traits_test_schema/messages/msg_12.hpp>
+#    include <traits_test_schema/messages/msg_13.hpp>
+#    include <traits_test_schema/messages/msg_14.hpp>
+#    include <traits_test_schema/messages/msg_15.hpp>
+#    include <traits_test_schema/messages/msg_16.hpp>
 
 #    include <traits_test_schema2/schema/schema.hpp>
 #endif
@@ -442,6 +452,7 @@ TEST(MessageTraitsTest, ProvidesTheSameValuesAsSchemaXml)
     ASSERT_EQ(traits::semantic_type(), "message semantic type");
     IS_SAME_TYPE(
         traits::value_type<char>, traits_test_schema::messages::msg_1<char>);
+    IS_SAME_TYPE(traits::schema_tag, traits_test_schema::schema);
     IS_NOEXCEPT(traits::name());
     IS_NOEXCEPT(traits::description());
     IS_NOEXCEPT(traits::id());
@@ -743,6 +754,295 @@ TYPED_TEST(DefaultOffsetTraitTest, ProvidesCorrectOffsetForConsecutiveFields)
     ASSERT_EQ(
         field_3_traits::offset(),
         field_2_traits::offset() + sizeof(typename field_2_traits::value_type));
+}
+
+TEST(DataTraitsTest, SizeBytesReturnsSumOfSizeOfLengthTypeAndGivenSize)
+{
+    using tag = traits_test_schema::schema::messages::msg_9::data_1;
+    using traits = sbepp::data_traits<tag>;
+    constexpr auto data_size = 2;
+
+    STATIC_ASSERT(
+        traits::size_bytes(data_size)
+        == sizeof(traits::length_type) + data_size);
+    IS_NOEXCEPT(traits::size_bytes(data_size));
+}
+
+TEST(GroupTraitsTest, EmptyGroupSizeIsHeaderSize)
+{
+    using tag = traits_test_schema::schema::messages::msg_10::group_2;
+    using traits = sbepp::group_traits<tag>;
+    constexpr auto group_size = 2;
+    STATIC_ASSERT(traits::block_length() == 0);
+
+    STATIC_ASSERT(
+        traits::size_bytes(group_size)
+        == sbepp::composite_traits<traits::dimension_type_tag>::size_bytes());
+    // group size doesn't matter because group has no fields
+    STATIC_ASSERT(
+        traits::size_bytes(group_size) == traits::size_bytes(group_size + 1));
+    IS_NOEXCEPT(traits::size_bytes(group_size));
+}
+
+TEST(GroupTraitsTest, FlatGroupSizeIsHeaderAndBlockLengthBySize)
+{
+    using tag = traits_test_schema::schema::messages::msg_10::group_1;
+    using traits = sbepp::group_traits<tag>;
+    constexpr auto group_size = 2;
+    STATIC_ASSERT(traits::block_length() != 0);
+    constexpr auto valid_size =
+        sbepp::composite_traits<traits::dimension_type_tag>::size_bytes()
+        + traits::block_length() * group_size;
+
+    STATIC_ASSERT(traits::size_bytes(group_size) == valid_size);
+    IS_NOEXCEPT(traits::size_bytes(group_size));
+}
+
+TEST(GroupTraitsTest, GroupWithDataSizeBytesHasTotalDataSizeParameter)
+{
+    using tag = traits_test_schema::schema::messages::msg_14::group_1::group_2;
+    using traits = sbepp::group_traits<tag>;
+    constexpr auto group_size = 2;
+    constexpr auto total_data_size = 10;
+    constexpr auto valid_size =
+        sbepp::composite_traits<traits::dimension_type_tag>::size_bytes()
+        + (traits::block_length()
+           + sbepp::data_traits<tag::data>::size_bytes(0))
+              * group_size
+        + total_data_size;
+
+    STATIC_ASSERT(
+        traits::size_bytes(group_size, total_data_size) == valid_size);
+    IS_NOEXCEPT(traits::size_bytes(group_size, total_data_size));
+}
+
+TEST(GroupTraitsTest, NestedGroupSizeBytesHasSizeParameterForEachGroup)
+{
+    using tag = traits_test_schema::schema::messages::msg_14::group_1;
+    using traits = sbepp::group_traits<tag>;
+    constexpr auto root_group_size = 2;
+    constexpr auto child_group_size = 3;
+    constexpr auto total_data_size = 10;
+    constexpr auto valid_size =
+        sbepp::composite_traits<traits::dimension_type_tag>::size_bytes()
+        + (traits::block_length()
+           + sbepp::group_traits<tag::group_2>::size_bytes(child_group_size, 0))
+              * root_group_size
+        + total_data_size;
+
+    STATIC_ASSERT(
+        traits::size_bytes(root_group_size, child_group_size, total_data_size)
+        == valid_size);
+    IS_NOEXCEPT(
+        traits::size_bytes(root_group_size, child_group_size, total_data_size));
+}
+
+TEST(MessageTraitsTest, EmptyMessageSizeIsHeaderSize)
+{
+    using tag = traits_test_schema::schema::messages::msg_7;
+    using traits = sbepp::message_traits<tag>;
+    STATIC_ASSERT(traits::block_length() == 0);
+    constexpr auto valid_size = sbepp::composite_traits<sbepp::schema_traits<
+        traits::schema_tag>::header_type_tag>::size_bytes();
+
+    STATIC_ASSERT(traits::size_bytes() == valid_size);
+    IS_NOEXCEPT(traits::size_bytes());
+}
+
+TEST(MessageTraitsTest, FlatMessageSizeIsHeaderSizeAndBlockLength)
+{
+    using tag = traits_test_schema::schema::messages::msg_8;
+    using traits = sbepp::message_traits<tag>;
+    STATIC_ASSERT(traits::block_length() != 0);
+    constexpr auto valid_size =
+        sbepp::composite_traits<sbepp::schema_traits<
+            traits::schema_tag>::header_type_tag>::size_bytes()
+        + traits::block_length();
+
+    STATIC_ASSERT(traits::size_bytes() == valid_size);
+    IS_NOEXCEPT(traits::size_bytes());
+}
+
+TEST(MessageTraitsTest, MessageWithDataSizeBytesHasTotalSizeBytesParameter)
+{
+    using tag = traits_test_schema::schema::messages::msg_9;
+    using traits = sbepp::message_traits<tag>;
+    constexpr auto data_1_size = 7;
+    constexpr auto data_2_size = 27;
+    constexpr auto total_data_size = data_1_size + data_2_size;
+    constexpr auto valid_size =
+        sbepp::composite_traits<sbepp::schema_traits<
+            traits::schema_tag>::header_type_tag>::size_bytes()
+        + traits::block_length()
+        + sbepp::data_traits<tag::data_1>::size_bytes(data_1_size)
+        + sbepp::data_traits<tag::data_2>::size_bytes(data_2_size);
+
+    STATIC_ASSERT(traits::size_bytes(total_data_size) == valid_size);
+    IS_NOEXCEPT(traits::size_bytes(total_data_size));
+}
+
+TEST(MessageTraitsTest, HasSizeParameterForEachGroupFromTopToBottom1)
+{
+    using tag = traits_test_schema::schema::messages::msg_10;
+    using traits = sbepp::message_traits<tag>;
+    constexpr auto group_1_size = 2;
+    constexpr auto group_2_size = 3;
+    constexpr auto valid_size =
+        sbepp::composite_traits<sbepp::schema_traits<
+            traits::schema_tag>::header_type_tag>::size_bytes()
+        + traits::block_length()
+        + sbepp::group_traits<tag::group_1>::size_bytes(group_1_size)
+        + sbepp::group_traits<tag::group_2>::size_bytes(group_2_size);
+
+    STATIC_ASSERT(traits::size_bytes(group_1_size, group_2_size) == valid_size);
+    IS_NOEXCEPT(traits::size_bytes(group_1_size, group_2_size));
+}
+
+TEST(MessageTraitsTest, HasSizeParameterForEachGroupFromTopToBottom2)
+{
+    using tag = traits_test_schema::schema::messages::msg_12;
+    using traits = sbepp::message_traits<tag>;
+    constexpr auto group_1_size = 2;
+    constexpr auto group_2_size = 3;
+    constexpr auto valid_size =
+        sbepp::composite_traits<sbepp::schema_traits<
+            traits::schema_tag>::header_type_tag>::size_bytes()
+        + traits::block_length()
+        + sbepp::group_traits<tag::group_1>::size_bytes(group_1_size)
+        + sbepp::group_traits<tag::group_2>::size_bytes(group_2_size);
+
+    STATIC_ASSERT(traits::size_bytes(group_1_size, group_2_size) == valid_size);
+    IS_NOEXCEPT(traits::size_bytes(group_1_size, group_2_size));
+}
+
+TEST(MessageTraitsTest, HasTrailingTotalDataSizeParameterIfHasDataAtAnyLevel1)
+{
+    using tag = traits_test_schema::schema::messages::msg_11;
+    using traits = sbepp::message_traits<tag>;
+    constexpr auto total_data_size = 10;
+    constexpr auto group_size = 4;
+    constexpr auto valid_size =
+        sbepp::composite_traits<sbepp::schema_traits<
+            traits::schema_tag>::header_type_tag>::size_bytes()
+        + traits::block_length()
+        + sbepp::group_traits<tag::group>::size_bytes(group_size)
+        + sbepp::data_traits<tag::data>::size_bytes(total_data_size);
+
+    STATIC_ASSERT(
+        traits::size_bytes(group_size, total_data_size) == valid_size);
+    IS_NOEXCEPT(traits::size_bytes(group_size, total_data_size));
+}
+
+TEST(MessageTraitsTest, HasSizeParameterForEachGroupFromTopToBottom3)
+{
+    using tag = traits_test_schema::schema::messages::msg_13;
+    using traits = sbepp::message_traits<tag>;
+    constexpr auto group_1_size = 2;
+    constexpr auto group_1_group_2_size = 3;
+    constexpr auto valid_size =
+        sbepp::composite_traits<sbepp::schema_traits<
+            traits::schema_tag>::header_type_tag>::size_bytes()
+        + traits::block_length()
+        + sbepp::group_traits<tag::group_1>::size_bytes(
+            group_1_size, group_1_group_2_size);
+
+    STATIC_ASSERT(
+        traits::size_bytes(group_1_size, group_1_group_2_size) == valid_size);
+    IS_NOEXCEPT(traits::size_bytes(group_1_size, group_1_group_2_size));
+}
+
+TEST(MessageTraitsTest, HasTrailingTotalDataSizeParameterIfHasDataAtAnyLevel2)
+{
+    using tag = traits_test_schema::schema::messages::msg_14;
+    using traits = sbepp::message_traits<tag>;
+    constexpr auto total_data_size = 10;
+    constexpr auto group_1_size = 2;
+    constexpr auto group_1_group_2_size = 3;
+    constexpr auto valid_size =
+        sbepp::composite_traits<sbepp::schema_traits<
+            traits::schema_tag>::header_type_tag>::size_bytes()
+        + traits::block_length()
+        + sbepp::group_traits<tag::group_1>::size_bytes(
+            group_1_size, group_1_group_2_size, total_data_size);
+
+    STATIC_ASSERT(
+        traits::size_bytes(group_1_size, group_1_group_2_size, total_data_size)
+        == valid_size);
+    IS_NOEXCEPT(traits::size_bytes(
+        group_1_size, group_1_group_2_size, total_data_size));
+}
+
+TEST(MessageTraitsTest, HasTrailingTotalDataSizeParameterIfHasDataAtAnyLevel3)
+{
+    using tag = traits_test_schema::schema::messages::msg_15;
+    using traits = sbepp::message_traits<tag>;
+    constexpr auto group_1_group_2_data_size = 3;
+    constexpr auto group_1_data_size = 6;
+    constexpr auto msg_data_size = 10;
+    constexpr auto total_data_size =
+        group_1_group_2_data_size + group_1_data_size + msg_data_size;
+    constexpr auto group_1_size = 2;
+    constexpr auto group_1_group_2_size = 3;
+    constexpr auto valid_size =
+        sbepp::composite_traits<sbepp::schema_traits<
+            traits::schema_tag>::header_type_tag>::size_bytes()
+        + traits::block_length()
+        + sbepp::group_traits<tag::group_1>::size_bytes(
+            group_1_size,
+            group_1_group_2_size,
+            group_1_group_2_data_size + group_1_data_size)
+        + sbepp::data_traits<tag::data>::size_bytes(msg_data_size);
+
+    STATIC_ASSERT(
+        traits::size_bytes(group_1_size, group_1_group_2_size, total_data_size)
+        == valid_size);
+    IS_NOEXCEPT(traits::size_bytes(
+        group_1_size, group_1_group_2_size, total_data_size));
+}
+
+TEST(MessageTraitsTest, AddsLevelDepthSuffixToAmbiguousSizeBytesParameters)
+{
+    // here, we mostly test that code compiles, without adding the `_<depth>`
+    // suffix, `size_bytes` would have multiple parameters with the same name
+    // and compilation error
+    using tag = traits_test_schema::schema::messages::msg_16;
+    using traits = sbepp::message_traits<tag>;
+    constexpr auto group_1_size = 1;
+    constexpr auto group_1_group_2_size = 2;
+    constexpr auto group_1_group_2_size_0 = 3;
+    constexpr auto group_3_size = 4;
+    constexpr auto group_3_group_1_group_2_size = 5;
+    constexpr auto group_3_group_1_size = 6;
+    constexpr auto group_3_group_1_group_2_size_2 = 7;
+    constexpr auto group_3_group_1_data_size = 9;
+    constexpr auto total_data_size = group_3_group_1_data_size;
+
+    constexpr auto valid_size =
+        sbepp::composite_traits<sbepp::schema_traits<
+            traits::schema_tag>::header_type_tag>::size_bytes()
+        + traits::block_length()
+        + sbepp::group_traits<tag::group_1>::size_bytes(
+            group_1_size, group_1_group_2_size)
+        + sbepp::group_traits<tag::group_1_group_2>::size_bytes(
+            group_1_group_2_size)
+        + sbepp::group_traits<tag::group_3>::size_bytes(
+            group_3_size,
+            group_3_group_1_group_2_size,
+            group_3_group_1_size,
+            group_3_group_1_group_2_size_2,
+            group_3_group_1_data_size);
+
+    STATIC_ASSERT(
+        traits::size_bytes(
+            group_1_size,
+            group_1_group_2_size,
+            group_1_group_2_size_0,
+            group_3_size,
+            group_3_group_1_group_2_size,
+            group_3_group_1_size,
+            group_3_group_1_group_2_size_2,
+            total_data_size)
+        == valid_size);
 }
 
 namespace constexpr_tests


### PR DESCRIPTION
Implements functionality discussed in #33.

Here's a brief overview of considered design options.

`sbepp::predict_size_bytes<T>(args...)` where `T` is a *representation* type (e.g. `schema_name::messages::msg_name`). While it was the initial choice, further investigation discovered multiple issues with this approach:
- being a generic function, it has to be a variadic template so can't expose required parameter names to the user
- representation types work with binary data, while this function is not related to binary data in any way
- representation types handle both encoding/decoding via the same interface, this function only makes sense for encoding
- even if easily possible, it's still questionable that this can be a `static` function of representation type because it's not related to its functionality, it doesn't need anything from it, nor it provides anything to it.

Since it's static in nature, potential implementation of `sbepp::predict_size_bytes<T>` would require an internal `struct` with `static` function and its specializations for each representation type. At this point this looks much more like a trait so the following approach was chosen.

`message_traits<Tag>::size_bytes(args...)`. Traits are already used to provide static/meta information, for example `composite_traits::size_bytes()` so after a bit of thinking, this looked like a natural way to go. While it's unlikely that someone will ever need `group_traits::size_bytes()` or `data_traits::size_bytes()`, they are used internally for `message_size::size_bytes()` so I see no reason to keep them private. Unlike `sbepp::predict_size_bytes()`, this approach allows user to see all the parameters which is definitely a benefit since they depend on the message structure. While using trait might be a bit verbose, #41 should make it possible to get trait tag from representation type to avoid using both types in code.