### PR TITLE
Better names mangling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.5.0
+
+- implement more user-friendly names mangling
+
+---
+
 # 1.4.2
 
 - add build and test GitHub action

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(sbepp
-    VERSION 1.4.2
+    VERSION 1.5.0
     LANGUAGES CXX
 )
 

--- a/doc/representation.md
+++ b/doc/representation.md
@@ -67,10 +67,36 @@ on schema names.
 ## Schema names
 
 `sbepp` preserves names of all schema entities without any modification. It
-means that messages, types, fields, etc. will have the same type/function names
-in the generated code. Of course standard
+means that messages, types, fields, etc. will have the same class/function names
+in the *public* part of the generated code. Of course standard
 C++ naming rules are still applied and usually you'll get an error from `sbeppc`
 if schema uses wrong name.
+
+### Names mangling {#names-mangling}
+
+\note Things described below are implementation details and are only provided to
+simplify understanding of compiler error messages. Don't rely on them directly.
+
+Although original names are preserved in public interface, sometimes underlying
+implementation is located in `detail` and a public alias is provided for it.
+Names from `detail` should never be used explicitly but in case of error,
+compiler usually uses them in error message so it's useful to know how they are
+formed.
+
+`sbepp` tries to preserve schema names for everything but when it's not
+possible, class name is mangled like `<original_name>_<N>` where `N` is a
+number. Group entries have class names like `<group_name>_entry` where
+`group_name` is a potentially mangled group name. Tag types can be mangled as
+well and their names always match those of the corresponding implementation
+types.
+
+For example, public encoding `User` is always accessible as
+`schema_name::types::User` but can actually be an alias to
+`schema_name::detail::types::User_0`. Similar, its tag is
+`schema_name::schema::types::User` but it can be an alias to
+`schema_name::detail::schema::types::User_0`. When schema doesn't have a lot of
+repetitive names, looking at the trailing class name is enough to understand
+which schema entity it represents.
 
 ---
 

--- a/sbeppc/src/sbepp/sbeppc/context_manager.hpp
+++ b/sbeppc/src/sbepp/sbeppc/context_manager.hpp
@@ -26,6 +26,7 @@ struct type_context
     std::string public_type;
     std::string underlying_type;
     std::string impl_type;
+    std::optional<std::string> mangled_name;
 };
 
 struct composite_context
@@ -36,6 +37,7 @@ struct composite_context
     std::string impl_name;
     std::string impl_type;
     std::string public_type;
+    std::optional<std::string> mangled_name;
 };
 
 struct ref_context
@@ -45,6 +47,7 @@ struct ref_context
     // is not optional
     offset_t offset_in_composite;
     std::string tag;
+    std::optional<std::string> mangled_name;
 };
 
 struct enum_valid_value_context
@@ -62,6 +65,7 @@ struct enumeration_context
     std::string public_type;
     std::string impl_type;
     std::string underlying_type;
+    std::optional<std::string> mangled_name;
 };
 
 struct set_choice_context
@@ -79,6 +83,7 @@ struct set_context
     std::string public_type;
     std::string impl_type;
     std::string underlying_type;
+    std::optional<std::string> mangled_name;
 };
 
 struct message_context
@@ -88,6 +93,7 @@ struct message_context
     std::string impl_type;
     std::string public_type;
     block_length_t actual_block_length;
+    std::optional<std::string> mangled_name;
 };
 
 struct field_context
@@ -109,6 +115,8 @@ struct group_context
     std::string entry_impl_type;
     std::string impl_type;
     block_length_t actual_block_length;
+    std::optional<std::string> mangled_name;
+    std::string entry_name;
 };
 
 struct data_context
@@ -122,6 +130,8 @@ struct message_schema_context
 {
     std::string name;
     std::string tag;
+    std::optional<std::string> mangled_tag_types_name;
+    std::optional<std::string> mangled_tag_messages_name;
 };
 
 template<typename T>

--- a/sbeppc/src/sbepp/sbeppc/context_manager.hpp
+++ b/sbeppc/src/sbepp/sbeppc/context_manager.hpp
@@ -21,7 +21,6 @@ struct type_context
     // here and below, set only if encoding is located inside a composite
     std::optional<offset_t> offset_in_composite;
     std::string tag;
-    std::string impl_name;
     bool is_template;
     std::string public_type;
     std::string underlying_type;
@@ -34,7 +33,6 @@ struct composite_context
     std::size_t size;
     std::optional<offset_t> offset_in_composite;
     std::string tag;
-    std::string impl_name;
     std::string impl_type;
     std::string public_type;
     std::optional<std::string> mangled_name;
@@ -47,7 +45,6 @@ struct ref_context
     // is not optional
     offset_t offset_in_composite;
     std::string tag;
-    std::optional<std::string> mangled_name;
 };
 
 struct enum_valid_value_context
@@ -61,7 +58,6 @@ struct enumeration_context
     std::optional<offset_t> offset_in_composite;
     std::string primitive_type;
     std::string tag;
-    std::string impl_name;
     std::string public_type;
     std::string impl_type;
     std::string underlying_type;
@@ -79,7 +75,6 @@ struct set_context
     std::optional<offset_t> offset_in_composite;
     std::string primitive_type;
     std::string tag;
-    std::string impl_name;
     std::string public_type;
     std::string impl_type;
     std::string underlying_type;
@@ -89,7 +84,6 @@ struct set_context
 struct message_context
 {
     std::string tag;
-    std::string impl_name;
     std::string impl_type;
     std::string public_type;
     block_length_t actual_block_length;
@@ -111,7 +105,6 @@ struct field_context
 struct group_context
 {
     std::string tag;
-    std::string impl_name;
     std::string entry_impl_type;
     std::string impl_type;
     block_length_t actual_block_length;

--- a/sbeppc/src/sbepp/sbeppc/main.cpp
+++ b/sbeppc/src/sbepp/sbeppc/main.cpp
@@ -162,8 +162,7 @@ int main(int argc, char** argv)
         sbe_schema_cpp_validator cpp_validator{reporter, ctx_manager};
         cpp_validator.validate(schema, config.schema_name);
 
-        names_generator names_gen;
-        names_gen.generate(schema, ctx_manager);
+        names_generator::generate(schema, ctx_manager);
 
         schema_compiler::compile(
             config.output_dir,

--- a/sbeppc/src/sbepp/sbeppc/main.cpp
+++ b/sbeppc/src/sbepp/sbeppc/main.cpp
@@ -11,6 +11,7 @@
 #include <sbepp/sbeppc/sbe_schema_validator.hpp>
 #include <sbepp/sbeppc/sbe_schema_cpp_validator.hpp>
 #include <sbepp/sbeppc/context_manager.hpp>
+#include <sbepp/sbeppc/names_generator.hpp>
 
 #include <fmt/core.h>
 
@@ -160,6 +161,9 @@ int main(int argc, char** argv)
 
         sbe_schema_cpp_validator cpp_validator{reporter, ctx_manager};
         cpp_validator.validate(schema, config.schema_name);
+
+        names_generator names_gen;
+        names_gen.generate(schema, ctx_manager);
 
         schema_compiler::compile(
             config.output_dir,

--- a/sbeppc/src/sbepp/sbeppc/main.cpp
+++ b/sbeppc/src/sbepp/sbeppc/main.cpp
@@ -156,11 +156,9 @@ int main(int argc, char** argv)
         const auto& schema = parser.get_message_schema();
 
         context_manager ctx_manager;
-        sbe_schema_validator sbe_validator{reporter};
-        sbe_validator.validate(schema, ctx_manager);
-
-        sbe_schema_cpp_validator cpp_validator{reporter, ctx_manager};
-        cpp_validator.validate(schema, config.schema_name);
+        sbe_schema_validator::validate(schema, ctx_manager, reporter);
+        sbe_schema_cpp_validator::validate(
+            schema, config.schema_name, ctx_manager, reporter);
 
         names_generator::generate(schema, ctx_manager);
 

--- a/sbeppc/src/sbepp/sbeppc/messages_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/messages_compiler.hpp
@@ -1693,8 +1693,6 @@ public:
         {
             on_message_cb(m.name, groups, implementation, dependencies, traits);
         }
-
-        // TODO: check message context impl_type, is it needed?
     }
 };
 } // namespace sbepp::sbeppc

--- a/sbeppc/src/sbepp/sbeppc/messages_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/messages_compiler.hpp
@@ -64,7 +64,7 @@ private:
             *schema, parsed.enum_name);
 
         return fmt::format(
-            "{}::{}", ctx_manager->get(e).impl_type, parsed.enumerator);
+            "{}::{}", ctx_manager->get(e).public_type, parsed.enumerator);
     }
 
     std::string value_ref_to_enum_value(const std::string_view value_ref) const
@@ -412,7 +412,7 @@ public:
     {
         const auto& t = get_header_element(c, "numInGroup");
 
-        return ctx_manager->get(t).impl_type;
+        return ctx_manager->get(t).public_type;
     }
 
     std::string make_group_header_filler(const sbe::group& g)

--- a/sbeppc/src/sbepp/sbeppc/names_generator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/names_generator.hpp
@@ -1,0 +1,416 @@
+#pragma once
+
+#include <sbepp/sbeppc/source_location.hpp>
+#include <sbepp/sbeppc/throw_error.hpp>
+#include <sbepp/sbeppc/context_manager.hpp>
+#include <sbepp/sbeppc/sbe.hpp>
+
+#include <fmt/format.h>
+
+#include <unordered_set>
+#include <variant>
+#include <limits>
+
+namespace sbepp::sbeppc
+{
+// This class is responsible for checking and generating mangled or non-mangled
+// (if possible) names for types and messages. If non-mangled name is not
+// possible, it tries to preserve the original name by adding a numerical suffix
+// to it. The main goal is to keep names in compiler error messages
+// understandable for a user.
+class names_generator
+{
+public:
+    void generate(
+        const sbe::message_schema& schema, context_manager& ctx_manager)
+    {
+        this->schema = &schema;
+        this->ctx_manager = &ctx_manager;
+        // TODO: clear all data members
+
+        generate_type_names();
+        generate_message_names();
+    }
+
+private:
+    const sbe::message_schema* schema{};
+    context_manager* ctx_manager{};
+    // all public type names
+    std::unordered_set<std::string> non_mangled_type_names;
+    // mangled public and anonymous (defined within composites) type names
+    std::unordered_set<std::string> mangled_type_names;
+    // these are similar to the above one but are message-related
+    std::unordered_set<std::string> non_mangled_message_names;
+    std::unordered_set<std::string> mangled_message_names;
+
+    static std::unordered_set<std::string> get_member_names(const sbe::type& t)
+    {
+        if((t.presence == field_presence::constant) || (t.length != 1))
+        {
+            // constants/arrays are represented using `static_array_ref` or
+            // naked types, they have no direct members
+            return {};
+        }
+        else if(t.presence == field_presence::required)
+        {
+            return {"min_value", "max_value"};
+        }
+        else
+        {
+            return {"min_value", "max_value", "null_value"};
+        }
+    }
+
+    static std::unordered_set<std::string>
+        get_member_names(const sbe::enumeration& e)
+    {
+        std::unordered_set<std::string> members;
+
+        for(const auto& valid_value : e.valid_values)
+        {
+            members.insert(valid_value.name);
+        }
+
+        return members;
+    }
+
+    static std::unordered_set<std::string> get_member_names(const sbe::set& s)
+    {
+        std::unordered_set<std::string> members;
+
+        for(const auto& choice : s.choices)
+        {
+            members.insert(choice.name);
+        }
+
+        return members;
+    }
+
+    static std::unordered_set<std::string>
+        get_member_names(const sbe::composite& c)
+    {
+        std::unordered_set<std::string> members;
+
+        for(const auto& element : c.elements)
+        {
+            std::visit(
+                [&members](const auto& actual_element)
+                {
+                    members.insert(actual_element.name);
+                },
+                element);
+        }
+
+        return members;
+    }
+
+    static std::unordered_set<std::string> get_member_names(const sbe::ref&)
+    {
+        // ref-s never have any direct members
+        return {};
+    }
+
+    template<typename... UnorderedSets>
+    static std::string make_mangled_name(
+        const std::string_view original_name,
+        const source_location& location,
+        const UnorderedSets&... reserved_names)
+    {
+        // TODO: should we start from `2`?
+        for(std::size_t n = 0; n != std::numeric_limits<std::size_t>::max();
+            n++)
+        {
+            const auto mangled_name = fmt::format("{}_{}", original_name, n);
+            const auto is_reserved =
+                (reserved_names.count(mangled_name) || ...);
+            if(!is_reserved)
+            {
+                return mangled_name;
+            }
+        }
+
+        throw_error(
+            "{}: can't generate a mangled name for `{}`",
+            location,
+            original_name);
+    }
+
+    void collect_non_mangled_type_names()
+    {
+        for(const auto& [name, enc] : schema->types)
+        {
+            std::visit(
+                [this](const auto& actual_enc)
+                {
+                    non_mangled_type_names.insert(actual_enc.name);
+                },
+                enc);
+        }
+    }
+
+    void handle_composite_elements(
+        const std::vector<sbe::composite_element>& elements)
+    {
+        for(const auto& e : elements)
+        {
+            // this is similar to public types handling with one difference: we
+            // always add type name (mangled or not) to the `mangled_type_names`
+            // since implementation types are in the same enclosing namespace
+
+            std::visit(
+                [this](const auto& actual_enc)
+                {
+                    const auto members = get_member_names(actual_enc);
+                    static constexpr auto is_ref =
+                        std::is_same_v<decltype(actual_enc), const sbe::ref&>;
+                    // composite elements (except ref-s) are implemented in
+                    // `detail::types` namespace
+                    if(members.count(actual_enc.name)
+                       || (!is_ref
+                           && mangled_type_names.count(actual_enc.name)))
+                    {
+                        const auto mangled_name = make_mangled_name(
+                            actual_enc.name,
+                            actual_enc.location,
+                            members,
+                            mangled_type_names,
+                            non_mangled_type_names);
+                        mangled_type_names.insert(mangled_name);
+                        ctx_manager->get(actual_enc).mangled_name =
+                            mangled_name;
+                    }
+                    else
+                    {
+                        mangled_type_names.insert(actual_enc.name);
+                    }
+
+                    if constexpr(std::is_same_v<
+                                     decltype(actual_enc),
+                                     const sbe::composite&>)
+                    {
+                        handle_composite_elements(actual_enc.elements);
+                    }
+                },
+                e);
+        }
+    }
+
+    void generate_type_names()
+    {
+        // collect all non-mangled names to avoid matching of mangled and
+        // non-mangled names. Although such a match won't lead to an error
+        // because those names will be in different namespaces, it will be just
+        // confusing
+        collect_non_mangled_type_names();
+
+        for(const auto& [name, enc] : schema->types)
+        {
+            std::visit(
+                [this](const auto& actual_enc)
+                {
+                    const auto members = get_member_names(actual_enc);
+                    if(members.count(actual_enc.name))
+                    {
+                        // encoding's name clashes with one of its members
+                        // (either in implementation class or in tag structure)
+                        // so we need a mangled name for it
+                        const auto mangled_name = make_mangled_name(
+                            actual_enc.name,
+                            actual_enc.location,
+                            members,
+                            mangled_type_names,
+                            non_mangled_type_names);
+                        mangled_type_names.insert(mangled_name);
+                        ctx_manager->get(actual_enc).mangled_name =
+                            mangled_name;
+                    }
+
+                    // TODO: refactor?
+                    if constexpr(std::is_same_v<
+                                     decltype(actual_enc),
+                                     const sbe::composite&>)
+                    {
+                        handle_composite_elements(actual_enc.elements);
+                    }
+                },
+                enc);
+        }
+
+        // implementation types are located inside `types` namespace but tags
+        // are inside `types` structure and it's not possible to have a child
+        // structure for a tag with the same name so we need a mangled name for
+        // it
+        if(non_mangled_type_names.count("types"))
+        {
+            const auto mangled_tag_types_name = make_mangled_name(
+                "types", schema->location, non_mangled_type_names);
+            ctx_manager->get(*schema).mangled_tag_types_name =
+                mangled_tag_types_name;
+        }
+    }
+
+    void collect_non_mangled_message_names()
+    {
+        for(const auto& m : schema->messages)
+        {
+            non_mangled_message_names.insert(m.name);
+        }
+    }
+
+    static std::unordered_set<std::string>
+        get_member_names(const sbe::level_members& members)
+    {
+        std::unordered_set<std::string> level_names;
+
+        for(const auto& f : members.fields)
+        {
+            level_names.insert(f.name);
+        }
+
+        for(const auto& g : members.groups)
+        {
+            level_names.insert(g.name);
+        }
+
+        for(const auto& d : members.data)
+        {
+            level_names.insert(d.name);
+        }
+
+        return level_names;
+    }
+
+    static std::string make_group_entry_name(const std::string_view group_name)
+    {
+        return fmt::format("{}_entry", group_name);
+    }
+
+    struct mangled_group_info
+    {
+        std::string group_name;
+        std::string entry_name;
+    };
+
+    template<typename... UnorderedSets>
+    static mangled_group_info make_mangled_group_info(
+        const std::string_view original_name,
+        const source_location& location,
+        const std::unordered_set<std::string>& entry_members,
+        const UnorderedSets&... reserved_names)
+    {
+        // TODO: should we start from `2`?
+        for(std::size_t n = 0; n != std::numeric_limits<std::size_t>::max();
+            n++)
+        {
+            const auto mangled_group_name =
+                fmt::format("{}_{}", original_name, n);
+            const auto entry_name = make_group_entry_name(mangled_group_name);
+            const auto is_reserved =
+                entry_members.count(mangled_group_name)
+                || (reserved_names.count(mangled_group_name) || ...)
+                || entry_members.count(entry_name)
+                || (reserved_names.count(entry_name) || ...);
+            if(!is_reserved)
+            {
+                return {mangled_group_name, entry_name};
+            }
+        }
+
+        throw_error(
+            "{}: can't generate a mangled name for `{}`",
+            location,
+            original_name);
+    }
+
+    void handle_message_level(const sbe::level_members& members)
+    {
+        // field names are never mangled because they never introduce new types,
+        // only refer to the existing ones. Their tags are never mangled too.
+
+        for(const auto& g : members.groups)
+        {
+            // group introduces a new level, although its name is preserved on
+            // the enclosing level, it and its entry needs a mangled name
+
+            // group implementation type itself doesn't have any named members
+            const auto entry_members = get_member_names(g.members);
+            const auto entry_name = make_group_entry_name(g.name);
+
+            // we want to preserve group name in both its implementation type
+            // and its entry type
+
+            // groups and their entries are implemented in the same namespace as
+            // mangled messages so their names should not clash
+            if(mangled_message_names.count(g.name)
+               || mangled_message_names.count(entry_name)
+               || entry_members.count(entry_name)
+               // group name should not clash with entry members because their
+               // tags are located directly within the group's one
+               || entry_members.count(g.name))
+            {
+                const auto mangled_group_info = make_mangled_group_info(
+                    g.name,
+                    g.location,
+                    entry_members,
+                    mangled_message_names,
+                    non_mangled_message_names);
+                mangled_message_names.insert(mangled_group_info.group_name);
+                ctx_manager->get(g).mangled_name =
+                    mangled_group_info.group_name;
+                mangled_message_names.insert(mangled_group_info.entry_name);
+                ctx_manager->get(g).entry_name = mangled_group_info.entry_name;
+            }
+            else
+            {
+                mangled_message_names.insert(g.name);
+                mangled_message_names.insert(entry_name);
+                ctx_manager->get(g).entry_name = entry_name;
+            }
+
+            handle_message_level(g.members);
+        }
+
+        // similar to fields, data tags are never mangled. They don't have
+        // implementation type name, it's always `dynamic_array_ref`.
+    }
+
+    void generate_message_names()
+    {
+        collect_non_mangled_message_names();
+
+        for(const auto& m : schema->messages)
+        {
+            const auto members = get_member_names(m.members);
+            if(members.count(m.name))
+            {
+                // message name clashes with its member so we need a mangled
+                // name for it
+                const auto mangled_name = make_mangled_name(
+                    m.name,
+                    m.location,
+                    members,
+                    mangled_message_names,
+                    non_mangled_message_names);
+                mangled_message_names.insert(mangled_name);
+                ctx_manager->get(m).mangled_name = mangled_name;
+            }
+
+            // handle message levels recursively, their names always go into
+            // mangled_message_names.
+            handle_message_level(m.members);
+        }
+
+        // implementation types are located inside `messages` namespace but tags
+        // are inside `messages` structure and it's not possible to have a child
+        // structure for a tag with the same name so we need a mangled name for
+        // it
+        if(non_mangled_message_names.count("messages"))
+        {
+            const auto mangled_tag_messages_name = make_mangled_name(
+                "messages", schema->location, non_mangled_message_names);
+            ctx_manager->get(*schema).mangled_tag_messages_name =
+                mangled_tag_messages_name;
+        }
+    }
+};
+} // namespace sbepp::sbeppc

--- a/sbeppc/src/sbepp/sbeppc/names_generator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/names_generator.hpp
@@ -18,7 +18,7 @@ namespace sbepp::sbeppc
 // (if possible) names for types and messages. If non-mangled name is not
 // possible, it tries to preserve the original name by adding a numerical suffix
 // to it. The main goal is to keep names in compiler error messages
-// understandable for a user.
+// understandable to a user.
 class names_generator
 {
 public:
@@ -40,7 +40,7 @@ private:
     std::unordered_set<std::string> non_mangled_type_names;
     // mangled public and anonymous (defined within composites) type names
     std::unordered_set<std::string> mangled_type_names;
-    // these are similar to the above one but are message-related
+    // these are similar to the above ones but are message-related
     std::unordered_set<std::string> non_mangled_message_names;
     std::unordered_set<std::string> mangled_message_names;
 
@@ -111,7 +111,6 @@ private:
         const source_location& location,
         const UnorderedSets&... reserved_names)
     {
-        // TODO: should we start from `2`?
         for(std::size_t n = 0; n != std::numeric_limits<std::size_t>::max();
             n++)
         {
@@ -304,7 +303,6 @@ private:
         const std::unordered_set<std::string>& entry_members,
         const UnorderedSets&... reserved_names)
     {
-        // TODO: should we start from `2`?
         for(std::size_t n = 0; n != std::numeric_limits<std::size_t>::max();
             n++)
         {

--- a/sbeppc/src/sbepp/sbeppc/names_generator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/names_generator.hpp
@@ -346,6 +346,10 @@ private:
             // groups and their entries are implemented in the same namespace as
             // mangled messages so their names should not clash
             if(mangled_message_names.count(g.name)
+               // at the moment mangled message name cannot match entry name
+               // because mangled names end with `_N` while entry names end with
+               // `_entry` but I prefer to keep this check to show the intent
+               // and in case mangling approach changes in the future
                || mangled_message_names.count(entry_name)
                || entry_members.count(entry_name)
                // group name should not clash with entry members because their

--- a/sbeppc/src/sbepp/sbeppc/sbe_schema_cpp_validator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/sbe_schema_cpp_validator.hpp
@@ -20,30 +20,35 @@ namespace sbepp::sbeppc
 class sbe_schema_cpp_validator
 {
 public:
-    sbe_schema_cpp_validator(ireporter& reporter, context_manager& ctx_manager)
-        : reporter{&reporter}, ctx_manager{&ctx_manager}
-    {
-    }
-
-    void validate(
+    static void validate(
         const sbe::message_schema& schema,
-        const std::optional<std::string>& custom_schema_name)
+        const std::optional<std::string>& custom_schema_name,
+        context_manager& ctx_manager,
+        ireporter& reporter)
     {
-        this->schema = &schema;
+        sbe_schema_cpp_validator validator{schema, ctx_manager, reporter};
 
         // at this point all names except schema one satisfy
         // `sbe_checker::is_sbe_symbolic_name` so they have valid C++ name
         // format but we still need to check them against reserved C++ names or
         // keywords
-        validate_schema_name(custom_schema_name);
-        validate_type_names();
-        validate_message_names();
+        validator.validate_schema_name(custom_schema_name);
+        validator.validate_type_names();
+        validator.validate_message_names();
     }
 
 private:
-    ireporter* reporter{};
-    context_manager* ctx_manager{};
     const sbe::message_schema* schema{};
+    context_manager* ctx_manager{};
+    ireporter* reporter{};
+
+    sbe_schema_cpp_validator(
+        const sbe::message_schema& schema,
+        context_manager& ctx_manager,
+        ireporter& reporter)
+        : schema{&schema}, ctx_manager{&ctx_manager}, reporter{&reporter}
+    {
+    }
 
     void validate_level_members(const sbe::level_members& members)
     {

--- a/sbeppc/src/sbepp/sbeppc/sbe_schema_validator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/sbe_schema_validator.hpp
@@ -27,18 +27,15 @@ namespace sbepp::sbeppc
 class sbe_schema_validator
 {
 public:
-    explicit sbe_schema_validator(ireporter& reporter) : reporter{&reporter}
+    static void validate(
+        const sbe::message_schema& schema,
+        context_manager& ctx_manager,
+        ireporter& reporter)
     {
-    }
+        sbe_schema_validator validator{schema, ctx_manager, reporter};
 
-    void validate(
-        const sbe::message_schema& schema, context_manager& ctx_manager)
-    {
-        this->schema = &schema;
-        this->ctx_manager = &ctx_manager;
-
-        validate_types();
-        validate_messages();
+        validator.validate_types();
+        validator.validate_messages();
     }
 
     static bool is_sbe_symbolic_name(const std::string_view name)
@@ -61,9 +58,9 @@ public:
     }
 
 private:
-    ireporter* reporter{};
     const sbe::message_schema* schema{};
     context_manager* ctx_manager{};
+    ireporter* reporter{};
 
     enum class processing_state
     {
@@ -74,6 +71,14 @@ private:
         encoding_processing_states;
     std::unordered_set<std::string> validated_group_headers;
     std::unordered_set<std::string> validated_data_headers;
+
+    sbe_schema_validator(
+        const sbe::message_schema& schema,
+        context_manager& ctx_manager,
+        ireporter& reporter)
+        : schema{&schema}, ctx_manager{&ctx_manager}, reporter{&reporter}
+    {
+    }
 
     static bool is_single_byte_type(const std::string_view type)
     {

--- a/sbeppc/src/sbepp/sbeppc/schema_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/schema_compiler.hpp
@@ -154,7 +154,8 @@ SBEPP_WARNINGS_ON();
                     "header_forward_decl",
                     make_schema_header_forward_declaration(
                         header_type.name,
-                        ctx_manager.get(header_type).mangled_name))));
+                        ctx_manager.get(header_type).mangled_name,
+                        schema_name))));
 
         // messages
         std::vector<std::string> message_includes;
@@ -291,7 +292,8 @@ private:
 
     static std::string make_schema_header_forward_declaration(
         const std::string_view public_name,
-        const std::optional<std::string>& mangled_name)
+        const std::optional<std::string>& mangled_name,
+        const std::string_view schema_name)
     {
         if(mangled_name)
         {
@@ -304,9 +306,18 @@ namespace types
 template<typename Byte>
 class {impl_name};
 }} // namespace types
-}} // namespace detail)",
+}} // namespace detail
+
+namespace types
+{{
+// TODO: test
+template<typename Byte>
+using {public_name} = ::{schema_name}::detail::types::{impl_name};
+}} // namespace types)",
                 // clang-format on
-                fmt::arg("impl_name", *mangled_name));
+                fmt::arg("impl_name", *mangled_name),
+                fmt::arg("public_name", public_name),
+                fmt::arg("schema_name", schema_name));
         }
         else
         {
@@ -315,10 +326,10 @@ class {impl_name};
 R"(namespace types
 {{
 template<typename Byte>
-class {impl_name};
+class {public_name};
 }} // namespace types)",
                 // clang-format on
-                fmt::arg("impl_name", public_name));
+                fmt::arg("public_name", public_name));
         }
     }
 };

--- a/sbeppc/src/sbepp/sbeppc/schema_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/schema_compiler.hpp
@@ -69,11 +69,11 @@ private:
         types_compiler tc{*schema, traits_gen, *ctx_manager};
         tc.compile(
             [this](
-                const auto name,
-                const auto detail_type,
-                const auto public_type,
-                const auto& dependencies,
-                const auto traits)
+                const std::string_view name,
+                const std::string_view detail_type,
+                const std::string_view public_type,
+                const std::unordered_set<std::string>& dependencies,
+                const std::string_view traits)
             {
                 const auto include_path =
                     std::filesystem::path{"types"} / name += ".hpp";
@@ -182,11 +182,11 @@ SBEPP_WARNINGS_ON();
         messages_compiler mc{*schema, traits_gen, *ctx_manager};
         mc.compile(
             [this](
-                const auto name,
-                const auto detail_message,
-                const auto public_message,
-                const auto& dependencies,
-                const auto traits)
+                const std::string_view name,
+                const std::string_view detail_message,
+                const std::string_view public_message,
+                const std::unordered_set<std::string>& dependencies,
+                const std::string_view traits)
             {
                 const auto include_path =
                     std::filesystem::path{"messages"} / name += ".hpp";

--- a/sbeppc/src/sbepp/sbeppc/schema_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/schema_compiler.hpp
@@ -81,7 +81,7 @@ private:
                     fmt::format("#include \"{}\"", include_path.string()));
                 const auto file_path = output_dir / schema_name / include_path;
 
-                fs_provider->write_file(
+                this->fs_provider->write_file(
                     file_path,
                     fmt::format(
                         // clang-format off
@@ -194,7 +194,7 @@ SBEPP_WARNINGS_ON();
                     fmt::format("#include \"{}\"", include_path.string()));
                 const auto file_path = output_dir / schema_name / include_path;
 
-                fs_provider->write_file(
+                this->fs_provider->write_file(
                     file_path,
                     fmt::format(
                         // clang-format off

--- a/sbeppc/src/sbepp/sbeppc/schema_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/schema_compiler.hpp
@@ -310,9 +310,8 @@ class {impl_name};
 
 namespace types
 {{
-// TODO: test
 template<typename Byte>
-using {public_name} = ::{schema_name}::detail::types::{impl_name};
+using {public_name} = ::{schema_name}::detail::types::{impl_name}<Byte>;
 }} // namespace types)",
                 // clang-format on
                 fmt::arg("impl_name", *mangled_name),

--- a/sbeppc/src/sbepp/sbeppc/tags_generator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/tags_generator.hpp
@@ -21,30 +21,28 @@ namespace sbepp::sbeppc
 class tags_generator
 {
 public:
-    tags_generator(
+    static std::string generate(
         const sbe::message_schema& schema, context_manager& ctx_manager)
-        : schema{&schema}, ctx_manager{&ctx_manager}
     {
-        generated = generate();
+        tags_generator generator{schema, ctx_manager};
+        return generator.generate();
     }
-
-    const std::string& get() const
-    {
-        return generated;
-    }
-
-    // TODO: add static function, make all other functions private
 
 private:
     const sbe::message_schema* schema{};
     context_manager* ctx_manager{};
-    std::string generated;
     std::unordered_map<std::string_view, bool> processed_types;
     std::string detail_types;
     std::string public_types;
     std::string detail_messages;
     std::string public_messages;
     std::vector<std::string> path;
+
+    tags_generator(
+        const sbe::message_schema& schema, context_manager& ctx_manager)
+        : schema{&schema}, ctx_manager{&ctx_manager}
+    {
+    }
 
     std::string make_public_tag(const std::string_view last) const
     {

--- a/sbeppc/src/sbepp/sbeppc/tags_generator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/tags_generator.hpp
@@ -163,6 +163,7 @@ R"(struct {name}
                             res += utils::make_type_alias(
                                 enc.name,
                                 make_type_impl_path(*ctx.mangled_name));
+                            res += '\n';
                         }
                         else
                         {
@@ -170,7 +171,6 @@ R"(struct {name}
                         }
                     }},
                 member);
-            res += '\n';
         }
 
         return res;

--- a/sbeppc/src/sbepp/sbeppc/traits_generator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/traits_generator.hpp
@@ -84,7 +84,7 @@ public:
             fmt::arg(
                 "header_type",
                 utils::make_alias_template(
-                    "header_type", header_context.impl_type)),
+                    "header_type", header_context.public_type)),
             fmt::arg(
                 "header_type_tag",
                 utils::make_type_alias("header_type_tag", header_context.tag)));

--- a/sbeppc/src/sbepp/sbeppc/types_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/types_compiler.hpp
@@ -65,7 +65,7 @@ private:
     std::string_view schema_name;
     sbe::byte_order_kind byte_order;
     on_public_type_cb_t on_public_type_cb;
-    std::unordered_map<std::string, bool> compiled_types;
+    std::unordered_map<std::string_view, bool> compiled_types;
     std::vector<std::unordered_set<std::string>> dependencies;
 
     struct compiled_composite
@@ -832,11 +832,10 @@ public:
     void compile_public_encoding(const sbe::encoding& enc)
     {
         const auto name = utils::get_encoding_name(enc);
-        const auto lowered_name = utils::to_lower(name);
         assert(!dependencies.empty());
         dependencies.back().emplace(name);
 
-        if(!compiled_types[lowered_name])
+        if(!compiled_types[name])
         {
             dependencies.emplace_back();
             std::string detail_type;
@@ -877,7 +876,7 @@ public:
                     }},
                 enc);
 
-            compiled_types[lowered_name] = true;
+            compiled_types[name] = true;
             if(needs_alias)
             {
                 public_type = make_alias(enc);

--- a/sbeppc/src/sbepp/sbeppc/types_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/types_compiler.hpp
@@ -271,7 +271,6 @@ public:
     void set_impl_and_public_types(
         const std::string& public_name, const bool is_public, Context& context)
     {
-        // TODO: do we need separate public and impl types?
         if(!is_public)
         {
             context.impl_type = fmt::format(

--- a/sbeppc/src/sbepp/sbeppc/types_compiler.hpp
+++ b/sbeppc/src/sbepp/sbeppc/types_compiler.hpp
@@ -551,7 +551,7 @@ public:
 
         return fmt::format(
             "::sbepp::to_underlying({}::{})",
-            ctx_manager->get(e).impl_type,
+            ctx_manager->get(e).public_type,
             parsed.enumerator);
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,3 +102,4 @@ foreach(version IN LISTS cpp_versions)
 endforeach()
 
 add_subdirectory(sbeppc_errors)
+add_subdirectory(naming_test)

--- a/test/naming_test/CMakeLists.txt
+++ b/test/naming_test/CMakeLists.txt
@@ -44,6 +44,10 @@ add_naming_test_schema("message_member_name_clash" "naming_test_schemas")
 add_naming_test_schema("mangled_message_name_clash" "naming_test_schemas")
 add_naming_test_schema("messages_message" "naming_test_schemas")
 add_naming_test_schema("mangled_message_header_name" "naming_test_schemas")
+add_naming_test_schema("group_member_name_clash" "naming_test_schemas")
+add_naming_test_schema("entry_name_clash" "naming_test_schemas")
+add_naming_test_schema("mangled_group_name_clash" "naming_test_schemas")
+add_naming_test_schema("mangled_entry_name_clash" "naming_test_schemas")
 
 set(target_name "naming_test")
 

--- a/test/naming_test/CMakeLists.txt
+++ b/test/naming_test/CMakeLists.txt
@@ -1,0 +1,50 @@
+function(add_naming_test_schema schema schema_list_var)
+    sbeppc_compile_schema(
+        TARGET_NAME compiled_naming_test_schemas
+        SCHEMA_FILE "${CMAKE_CURRENT_LIST_DIR}/${schema}.xml"
+        SCHEMA_NAME "${schema}"
+    )
+
+    list(APPEND ${schema_list_var} "${schema}")
+    set(${schema_list_var} "${${schema_list_var}}" PARENT_SCOPE)
+endfunction()
+
+function(create_naming_test_target target_name schemas)
+    add_executable(${target_name})
+
+    set(includes)
+
+    foreach(schema IN LISTS schemas)
+        string(APPEND includes "#include <${schema}/${schema}.hpp>\n")
+    endforeach()
+
+    configure_file("main.cpp.in" "main.cpp" @ONLY)
+
+    target_sources(${target_name}
+        PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}/main.cpp"
+    )
+
+    target_link_libraries(${target_name}
+        PRIVATE
+        compiled_naming_test_schemas
+    )
+endfunction()
+
+# ------------------------------------------------------------------------------
+
+set(naming_test_schemas)
+
+add_naming_test_schema("type_member_name_clash" "naming_test_schemas")
+add_naming_test_schema("public_private_type_name_clash" "naming_test_schemas")
+add_naming_test_schema("mangled_type_name_clash" "naming_test_schemas")
+add_naming_test_schema("types_type" "naming_test_schemas")
+
+set(target_name "naming_test")
+
+create_naming_test_target("${target_name}" "${naming_test_schemas}")
+
+add_test(
+    NAME "${target_name}"
+    COMMAND "${target_name}"
+)

--- a/test/naming_test/CMakeLists.txt
+++ b/test/naming_test/CMakeLists.txt
@@ -40,6 +40,11 @@ add_naming_test_schema("public_private_type_name_clash" "naming_test_schemas")
 add_naming_test_schema("mangled_type_name_clash" "naming_test_schemas")
 add_naming_test_schema("types_type" "naming_test_schemas")
 
+add_naming_test_schema("message_member_name_clash" "naming_test_schemas")
+add_naming_test_schema("mangled_message_name_clash" "naming_test_schemas")
+add_naming_test_schema("messages_message" "naming_test_schemas")
+add_naming_test_schema("mangled_message_header_name" "naming_test_schemas")
+
 set(target_name "naming_test")
 
 create_naming_test_target("${target_name}" "${naming_test_schemas}")

--- a/test/naming_test/entry_name_clash.xml
+++ b/test/naming_test/entry_name_clash.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="groupSizeEncoding">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="varDataEncoding">
+            <type name="length" primitiveType="uint32"/>
+            <type name="varData" primitiveType="uint8" length="0"/>
+        </composite>
+    </types>
+
+    <sbe:message name="message1" id="1">
+        <group name="group1" id="1">
+            <field name="group1_entry" id="2" type="uint32"/>
+        </group>
+    </sbe:message>
+
+    <sbe:message name="message2" id="2">
+        <group name="group2" id="1">
+            <group name="group2_entry" id="2"/>
+        </group>
+    </sbe:message>
+
+    <sbe:message name="message3" id="3">
+        <group name="group3" id="1">
+            <data name="group3_entry" id="2" type="varDataEncoding"/>
+        </group>
+    </sbe:message>
+</sbe:messageSchema>

--- a/test/naming_test/group_member_name_clash.xml
+++ b/test/naming_test/group_member_name_clash.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="groupSizeEncoding">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="varDataEncoding">
+            <type name="length" primitiveType="uint32"/>
+            <type name="varData" primitiveType="uint8" length="0"/>
+        </composite>
+    </types>
+
+    <sbe:message name="message1" id="1">
+        <group name="group_name" id="1">
+            <field name="group_name" id="2" type="uint32"/>
+        </group>
+    </sbe:message>
+
+    <sbe:message name="message2" id="2">
+        <group name="group_name" id="1">
+            <group name="group_name" id="2"/>
+        </group>
+    </sbe:message>
+
+    <sbe:message name="message3" id="3">
+        <group name="group_name" id="1">
+            <data name="group_name" id="2" type="varDataEncoding"/>
+        </group>
+    </sbe:message>
+
+    <sbe:message name="group_name2" id="4">
+        <field name="group_name2" id="2" type="uint32"/>
+    </sbe:message>
+
+    <sbe:message name="message5" id="5">
+        <group name="group_name2_0" id="1"/>
+    </sbe:message>
+</sbe:messageSchema>

--- a/test/naming_test/main.cpp.in
+++ b/test/naming_test/main.cpp.in
@@ -1,0 +1,6 @@
+@includes@
+
+int main()
+{
+    return 0;
+}

--- a/test/naming_test/mangled_entry_name_clash.xml
+++ b/test/naming_test/mangled_entry_name_clash.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="groupSizeEncoding">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="varDataEncoding">
+            <type name="length" primitiveType="uint32"/>
+            <type name="varData" primitiveType="uint8" length="0"/>
+        </composite>
+    </types>
+
+    <sbe:message name="group_name_0_entry" id="2"/>
+
+    <sbe:message name="message1" id="1">
+        <group name="group_name" id="1">
+            <field name="group_name_entry" id="2" type="uint32"/>
+            <group name="group_name_1_entry" id="3"/>
+        </group>
+    </sbe:message>
+</sbe:messageSchema>

--- a/test/naming_test/mangled_group_name_clash.xml
+++ b/test/naming_test/mangled_group_name_clash.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="groupSizeEncoding">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="varDataEncoding">
+            <type name="length" primitiveType="uint32"/>
+            <type name="varData" primitiveType="uint8" length="0"/>
+        </composite>
+    </types>
+
+    <sbe:message name="group_name_0" id="1"/>
+
+    <sbe:message name="group_name" id="2">
+        <field name="group_name" id="1" type="uint32"/>
+    </sbe:message>
+
+    <sbe:message name="message1" id="3">
+        <group name="group_name" id="1">
+            <field name="group_name" id="2" type="uint32"/>
+            <field name="group_name_2" id="3" type="uint32"/>
+        </group>
+    </sbe:message>
+</sbe:messageSchema>

--- a/test/naming_test/mangled_message_header_name.xml
+++ b/test/naming_test/mangled_message_header_name.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+            <type name="messageHeader" primitiveType="uint16"/>
+        </composite>
+    </types>
+
+    <sbe:message name="message" id="1"/>
+</sbe:messageSchema>

--- a/test/naming_test/mangled_message_name_clash.xml
+++ b/test/naming_test/mangled_message_name_clash.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="groupSizeEncoding">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="varDataEncoding">
+            <type name="length" primitiveType="uint32"/>
+            <type name="varData" primitiveType="uint8" length="0"/>
+        </composite>
+    </types>
+
+    <sbe:message name="message" id="1">
+        <field name="message" id="0" type="uint32"/>
+        <field name="message_0" id="1" type="uint32"/>
+        <group name="message_1" id="2"/>
+        <data name="message_2" id="3" type="varDataEncoding"/>
+    </sbe:message>
+
+    <sbe:message name="message_3" id="2"/>
+</sbe:messageSchema>

--- a/test/naming_test/mangled_type_name_clash.xml
+++ b/test/naming_test/mangled_type_name_clash.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <type name="max_value" primitiveType="uint32" presence="required"/>
+        <type name="min_value" primitiveType="uint32" presence="required"/>
+        <type name="null_value" primitiveType="uint32" presence="optional"/>
+
+        <type name="max_value_0" primitiveType="uint32" presence="required"/>
+        <type name="min_value_0" primitiveType="uint32" presence="required"/>
+        <type name="null_value_0" primitiveType="uint32" presence="optional"/>
+
+        <composite name="composite1">
+            <type name="max_value_1" primitiveType="uint32" presence="required"/>
+            <type name="min_value_1" primitiveType="uint32" presence="required"/>
+            <type name="null_value_1" primitiveType="uint32" presence="optional"/>
+        </composite>
+
+        <set name="set_name" encodingType="uint8">
+            <choice name="set_name">0</choice>
+            <choice name="set_name_0">1</choice>
+        </set>
+
+        <set name="set_name_1" encodingType="uint8"/>
+
+        <composite name="composite2">
+            <set name="set_name_2" encodingType="uint8"/>
+        </composite>
+
+        <enum name="enum_name" encodingType="uint8">
+            <validValue name="enum_name">1</validValue>
+            <validValue name="enum_name_0">2</validValue>
+        </enum>
+
+        <enum name="enum_name_1" encodingType="uint8"/>
+
+        <composite name="composite3">
+            <enum name="enum_name_2" encodingType="uint8"/>
+        </composite>
+
+        <composite name="composite_name">
+            <type name="composite_name" primitiveType="uint16"/>
+            <type name="composite_name_0" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="composite_name_1"/>
+
+        <composite name="composite4">
+            <composite name="composite_name_2"/>
+        </composite>
+
+        <composite name="composite5">
+            <type name="max_value" primitiveType="uint32" presence="required"/>
+            <type name="min_value" primitiveType="uint32" presence="required"/>
+            <type name="null_value" primitiveType="uint32" presence="optional"/>
+
+            <type name="max_value_0" primitiveType="uint32" presence="required"/>
+            <type name="min_value_0" primitiveType="uint32" presence="required"/>
+            <type name="null_value_0" primitiveType="uint32" presence="optional"/>
+
+            <composite name="composite1">
+                <type name="max_value_1" primitiveType="uint32" presence="required"/>
+                <type name="min_value_1" primitiveType="uint32" presence="required"/>
+                <type name="null_value_1" primitiveType="uint32" presence="optional"/>
+            </composite>
+
+            <set name="set_name" encodingType="uint8">
+                <choice name="set_name">0</choice>
+                <choice name="set_name_0">1</choice>
+            </set>
+
+            <set name="set_name_1" encodingType="uint8"/>
+
+            <composite name="composite2">
+                <set name="set_name_2" encodingType="uint8"/>
+            </composite>
+
+            <enum name="enum_name" encodingType="uint8">
+                <validValue name="enum_name">1</validValue>
+                <validValue name="enum_name_0">2</validValue>
+            </enum>
+
+            <enum name="enum_name_1" encodingType="uint8"/>
+
+            <composite name="composite3">
+                <enum name="enum_name_2" encodingType="uint8"/>
+            </composite>
+
+            <composite name="composite_name">
+                <type name="composite_name" primitiveType="uint16"/>
+                <type name="composite_name_0" primitiveType="uint16"/>
+            </composite>
+
+            <composite name="composite_name_1"/>
+
+            <composite name="composite4">
+                <composite name="composite_name_2"/>
+            </composite>
+        </composite>
+    </types>
+</sbe:messageSchema>

--- a/test/naming_test/message_member_name_clash.xml
+++ b/test/naming_test/message_member_name_clash.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="groupSizeEncoding">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="varDataEncoding">
+            <type name="length" primitiveType="uint32"/>
+            <type name="varData" primitiveType="uint8" length="0"/>
+        </composite>
+    </types>
+
+    <sbe:message name="message1" id="1">
+        <field name="message1" id="1" type="uint32"/>
+    </sbe:message>
+
+    <sbe:message name="message2" id="2">
+        <group name="message2" id="1"/>
+    </sbe:message>
+
+    <sbe:message name="message3" id="3">
+        <data name="message3" id="1" type="varDataEncoding"/>
+    </sbe:message>
+</sbe:messageSchema>

--- a/test/naming_test/messages_message.xml
+++ b/test/naming_test/messages_message.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+    </types>
+
+    <sbe:message name="messages" id="1"/>
+    <sbe:message name="messages_0" id="2"/>
+</sbe:messageSchema>

--- a/test/naming_test/public_private_type_name_clash.xml
+++ b/test/naming_test/public_private_type_name_clash.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <type name="type_name" primitiveType="uint32" presence="required"/>
+
+        <set name="set_name" encodingType="uint8">
+            <choice name="C1">0</choice>
+        </set>
+
+        <enum name="enum_name" encodingType="uint8">
+            <validValue name="E1">1</validValue>
+        </enum>
+
+        <composite name="composite_name"/>
+
+        <composite name="parent_composite">
+            <type name="type_name" primitiveType="uint32" presence="required"/>
+
+            <set name="set_name" encodingType="uint8">
+                <choice name="C2">0</choice>
+            </set>
+
+            <enum name="enum_name" encodingType="uint8">
+                <validValue name="E2">1</validValue>
+            </enum>
+
+            <composite name="composite_name"/>
+        </composite>
+    </types>
+</sbe:messageSchema>

--- a/test/naming_test/type_member_name_clash.xml
+++ b/test/naming_test/type_member_name_clash.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <type name="max_value" primitiveType="uint32" presence="required"/>
+        <type name="min_value" primitiveType="uint32" presence="required"/>
+        <type name="null_value" primitiveType="uint32" presence="optional"/>
+
+        <set name="set_name" encodingType="uint8">
+            <choice name="set_name">0</choice>
+        </set>
+
+        <enum name="enum_name" encodingType="uint8">
+            <validValue name="enum_name">1</validValue>
+        </enum>
+
+        <composite name="composite_name1">
+            <type name="composite_name1" primitiveType="uint16"/>
+        </composite>
+
+        <composite name="composite_name2">
+            <set name="composite_name2" encodingType="uint8"/>
+        </composite>
+
+        <composite name="composite_name3">
+            <enum name="composite_name3" encodingType="uint8"/>
+        </composite>
+
+        <composite name="composite_name4">
+            <composite name="composite_name4"/>
+        </composite>
+
+        <composite name="composite_name5">
+            <ref name="composite_name5" type="set_name"/>
+        </composite>
+
+        <!-- same as above but for anonymous types -->
+        <composite name="parent_composite">
+            <type name="max_value" primitiveType="uint32" presence="required"/>
+            <type name="min_value" primitiveType="uint32" presence="required"/>
+            <type name="null_value" primitiveType="uint32" presence="optional"/>
+
+            <set name="set_name" encodingType="uint8">
+                <choice name="set_name">0</choice>
+            </set>
+
+            <enum name="enum_name" encodingType="uint8">
+                <validValue name="enum_name">1</validValue>
+            </enum>
+
+            <composite name="composite_name1">
+                <type name="composite_name1" primitiveType="uint16"/>
+            </composite>
+
+            <composite name="composite_name2">
+                <set name="composite_name2" encodingType="uint8"/>
+            </composite>
+
+            <composite name="composite_name3">
+                <enum name="composite_name3" encodingType="uint8"/>
+            </composite>
+
+            <composite name="composite_name4">
+                <composite name="composite_name4"/>
+            </composite>
+
+            <composite name="composite_name5">
+                <ref name="composite_name5" type="set_name"/>
+            </composite>
+        </composite>
+    </types>
+</sbe:messageSchema>

--- a/test/naming_test/types_type.xml
+++ b/test/naming_test/types_type.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="schema_name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example base schema which can be extended."
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <type name="types" primitiveType="uint32" presence="required"/>
+        <set name="types_0" encodingType="uint8"/>
+        <enum name="types_1" encodingType="uint8"/>
+        <composite name="types_2"/>
+    </types>
+</sbe:messageSchema>


### PR DESCRIPTION
Prior to this change, all names were mangled in a way like `message_N`, `type_N` and so on. From compiler error messages it was hard to understand the problematic schema entity. With this PR:
- mangled names follow `<original_name>_N` pattern
- group entries have names like `<group_name>_entry`
- for public types and messages mangling is not used at all whenever possible

With the above changes it's now much easier to figure out the mapping between schema entities and implementation types.