### PR TITLE
make `traits_tag` for entries provide group tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.7.0
+
+- make `sbepp::traits_tag` for group entries provide group tag
+- add missing `sbepp::is_group_entry_v` and corresponding concept
+
+---
+
 # 1.6.0
 
 - add children tag lists to various traits

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(sbepp
-    VERSION 1.6.0
+    VERSION 1.7.0
     LANGUAGES CXX
 )
 

--- a/sbepp/src/sbepp/sbepp.hpp
+++ b/sbepp/src/sbepp/sbepp.hpp
@@ -4644,8 +4644,9 @@ public:
  * @tparam ValueType representation type
  *
  * Can be used to avoid typing both representation and tag types explicitly in
- * code. Available for messages, groups and all schema types except numeric
- * constants. Not available for `<data>` members.
+ * code. Available for messages, groups, entries and all schema types except
+ * numeric constants. Group entry representation is mapped to the enclosing
+ * group tag. Not available for `<data>` members.
  *
  * Example:
  * ```cpp

--- a/sbeppc/src/sbepp/sbeppc/traits_generator.hpp
+++ b/sbeppc/src/sbepp/sbeppc/traits_generator.hpp
@@ -1258,6 +1258,7 @@ public:
 }};
 
 {traits_tag}
+{entry_traits_tag}
 )",
             // clang-format on
             fmt::arg("tag", group_context.tag),
@@ -1290,6 +1291,10 @@ public:
                 "traits_tag",
                 make_templated_traits_tag(
                     group_context.impl_type, group_context.tag)),
+            fmt::arg(
+                "entry_traits_tag",
+                make_templated_traits_tag(
+                    group_context.entry_impl_type, group_context.tag)),
             fmt::arg(
                 "field_tags",
                 make_type_list_alias("field_tags", get_tags(g.members.fields))),

--- a/test/src/sbepp/test/traits.test.cpp
+++ b/test/src/sbepp/test/traits.test.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2023, Oleksandr Koval
 
+#include "sbepp/sbepp.hpp"
 #include <traits_test_schema/types/messageHeader.hpp>
 #include <traits_test_schema/types/groupSizeEncoding.hpp>
 #include <traits_test_schema/types/customGroupSizeEncoding.hpp>
@@ -1354,6 +1355,14 @@ TYPED_TEST(SimpleValueTypeTraitsTagTest, ProvidesCorrectTraitsTag)
     using representation_type = typename TestFixture::traits::value_type;
 
     IS_SAME_TYPE(sbepp::traits_tag_t<representation_type>, tag);
+}
+
+TEST(GroupEntryTraitsTagTest, ProvidesGroupTag)
+{
+    using group_tag = traits_test_schema::schema::messages::msg_4::group_1;
+    using entry_type = sbepp::group_traits<group_tag>::entry_type<char>;
+
+    IS_SAME_TYPE(sbepp::traits_tag_t<entry_type>, group_tag);
 }
 
 namespace constexpr_tests


### PR DESCRIPTION
Turns out this approach is the only option as adding type aliases directly inside the group entry class is impossible due to potential name clashes with schema names.

Fixes #94