### PR TITLE
OleksandrKvl/sbeppc compile schema alias

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,12 +54,12 @@ jobs:
           pip install conan
           source ~/.profile
           conan config install --type dir ./.github/conan_config
-          conan install . -of=build --build=missing
-          cmake -B build -DSBEPP_BUILD_TESTS=ON -DSBEPP_SEPARATE_TESTS=OFF --preset conan-debug
-          cmake --build build --preset conan-debug --parallel $(nproc)
+          conan install . --build=missing
+          cmake -DSBEPP_BUILD_TESTS=ON -DSBEPP_SEPARATE_TESTS=OFF --preset conan-debug
+          cmake --build --preset conan-debug
 
       - name: Run tests
-        run: ctest --test-dir build --output-on-failure --parallel --build-config Debug
+        run: ctest --output-on-failure --preset conan-debug
 
   build-windows:
     runs-on: windows-2022
@@ -74,10 +74,9 @@ jobs:
         pip install conan
         conan profile detect
         conan profile show
-        conan install . -of=build --build=missing -s build_type=Debug
-        cmake -B build -DSBEPP_BUILD_TESTS=ON -DSBEPP_SEPARATE_TESTS=OFF --preset conan-default
-        $threads = (Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors
-        cmake --build build --preset conan-debug --parallel $threads
+        conan install . --build=missing -s build_type=Debug
+        cmake -DSBEPP_BUILD_TESTS=ON -DSBEPP_SEPARATE_TESTS=OFF --preset conan-default
+        cmake --build --preset conan-debug
 
     - name: Run tests
-      run: ctest --test-dir build --output-on-failure --parallel --build-config Debug
+      run: ctest --output-on-failure --preset conan-debug

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(${target}
 
 target_link_libraries(${target}
     PRIVATE
-    compiled_benchmark_schemas
+    compiled_benchmark_schemas::compiled_benchmark_schemas
     benchmark::benchmark
     benchmark::benchmark_main
 )

--- a/cmake/sbeppcHelpers.cmake
+++ b/cmake/sbeppcHelpers.cmake
@@ -148,6 +148,8 @@ endfunction()
 #   SCHEMA_FILE: the path to schema XML file
 #   TARGET_NAME: the name of the generated `INTERFACE` library. A single target
 #       can be used to compile multiple schemas.
+#   TARGET_ALIAS: optional, alias name for the generated target. Defaults to
+#       `${TARGET_NAME}::${TARGET_NAME}`.
 #   OUTPUT_DIR: optional, the directory in which `sbeppc` will generate headers.
 #       Defaults to `${CMAKE_BINARY_DIR}/sbeppc_generated`.
 #   SCHEMA_NAME: optional, overrides schema name from XML
@@ -160,11 +162,11 @@ endfunction()
 #     SCHEMA_FILE "schema.xml"
 # )
 # add_executable(exe)
-# target_link_libraries(exe PRIVATE compiled_schema)
+# target_link_libraries(exe PRIVATE compiled_schema::compiled_schema)
 # 
 function(sbeppc_compile_schema)
     set(one_value_args
-        SCHEMA_FILE TARGET_NAME OUTPUT_DIR SCHEMA_NAME SBEPPC_PATH
+        SCHEMA_FILE TARGET_NAME OUTPUT_DIR SCHEMA_NAME SBEPPC_PATH TARGET_ALIAS
     )
     sbepp_parse_arguments(arg "" "${one_value_args}" "" "${ARGN}")
 
@@ -192,6 +194,14 @@ function(sbeppc_compile_schema)
 
     if(NOT TARGET ${arg_TARGET_NAME})
         add_library(${arg_TARGET_NAME} INTERFACE)
+
+        if(DEFINED arg_TARGET_ALIAS)
+            add_library(${arg_TARGET_ALIAS} ALIAS ${arg_TARGET_NAME})
+        else()
+            add_library(
+                ${arg_TARGET_NAME}::${arg_TARGET_NAME} ALIAS ${arg_TARGET_NAME})
+        endif()
+
         target_link_libraries(${arg_TARGET_NAME}
             INTERFACE
             sbepp::sbepp

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -7,3 +7,6 @@ gtest/1.12.1
 [generators]
 CMakeDeps
 CMakeToolchain
+
+[layout]
+cmake_layout

--- a/doc/integration.md
+++ b/doc/integration.md
@@ -25,6 +25,8 @@ Parameters:
 - `SCHEMA_FILE`, the path to schema XML file.
 - `TARGET_NAME`, the name of the generated `INTERFACE` library. Same target can
     be used to compile multiple schemas.
+- `TARGET_ALIAS`, optional, alias name for the generated target. Defaults to
+       `${TARGET_NAME}::${TARGET_NAME}`.
 - `OUTPUT_DIR`, optional, the directory in which `sbeppc` will generate headers.
     Defaults to `${CMAKE_BINARY_DIR}/sbeppc_generated`.
 - `SCHEMA_NAME`, optional, overrides schema name from XML.
@@ -50,7 +52,7 @@ sbeppc_compile_schema(
 
 add_executable(exe)
 # generated target carries all necessary dependencies, just link to it
-target_link_libraries(exe PRIVATE compiled_schemas)
+target_link_libraries(exe PRIVATE compiled_schemas::compiled_schemas)
 ```
 
 ---

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ foreach(schema IN LISTS test_schemas)
         # actually, only `traits_test_schema2` needs explicit name
         SCHEMA_NAME "${schema}"
         TARGET_NAME compiled_test_schemas
+        TARGET_ALIAS compiled_test_schemas::test_alias
     )
 endforeach()
 
@@ -84,7 +85,7 @@ function(add_test_binary cpp_version)
         
     target_link_libraries(${test_name}
         PRIVATE
-        compiled_test_schemas
+        compiled_test_schemas::test_alias
         GTest::gtest_main
         fmt::fmt
     )

--- a/test/naming_test/CMakeLists.txt
+++ b/test/naming_test/CMakeLists.txt
@@ -27,7 +27,7 @@ function(create_naming_test_target target_name schemas)
 
     target_link_libraries(${target_name}
         PRIVATE
-        compiled_naming_test_schemas
+        compiled_naming_test_schemas::compiled_naming_test_schemas
     )
 endfunction()
 


### PR DESCRIPTION
Target aliases is a classic way to mention/link libraries in CMake. Somehow this simple feature was missed by the `sbeppc_compile_schema`.